### PR TITLE
feat: 확장 프로그램 엔드포인트 예외 처리 및 중복 등록 방지 개선

### DIFF
--- a/src/main/java/kr/or/kosa/snippets/snippetExt/exception/DuplicateSnippetException.java
+++ b/src/main/java/kr/or/kosa/snippets/snippetExt/exception/DuplicateSnippetException.java
@@ -1,0 +1,8 @@
+package kr.or.kosa.snippets.snippetExt.exception;
+
+public class DuplicateSnippetException extends RuntimeException {
+    public DuplicateSnippetException(String message) {
+        super(message);
+    }
+}
+

--- a/src/main/java/kr/or/kosa/snippets/snippetExt/exception/SnippetExceptionHandler.java
+++ b/src/main/java/kr/or/kosa/snippets/snippetExt/exception/SnippetExceptionHandler.java
@@ -1,11 +1,11 @@
 package kr.or.kosa.snippets.snippetExt.exception;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.nio.file.AccessDeniedException;
 import java.util.Map;
 import jakarta.persistence.EntityNotFoundException;
 
@@ -32,6 +32,19 @@ public class SnippetExceptionHandler {
     public ResponseEntity<?> handleNotFound(EntityNotFoundException ex) {
         return ResponseEntity.status(404).body(Map.of(
             "error", "Not Found",
+            "message", ex.getMessage()
+        ));
+    }
+
+    @ExceptionHandler(DuplicateSnippetException.class)
+    public ResponseEntity<?> handleDuplicate(DuplicateSnippetException ex) {
+        return ResponseEntity.status(409).body(Map.of("error", ex.getMessage()));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<?> handleIllegalArgument(IllegalArgumentException ex) {
+        return ResponseEntity.badRequest().body(Map.of(
+            "error", "Invalid Argument",
             "message", ex.getMessage()
         ));
     }

--- a/src/main/java/kr/or/kosa/snippets/snippetExt/exception/SnippetExceptionHandler.java
+++ b/src/main/java/kr/or/kosa/snippets/snippetExt/exception/SnippetExceptionHandler.java
@@ -1,0 +1,39 @@
+package kr.or.kosa.snippets.snippetExt.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.nio.file.AccessDeniedException;
+import java.util.Map;
+import jakarta.persistence.EntityNotFoundException;
+
+@RestControllerAdvice(basePackages = "kr.or.kosa.snippets.snippetExt")
+public class SnippetExceptionHandler {
+
+    @ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
+    public ResponseEntity<?> handleUnauthenticated(AuthenticationCredentialsNotFoundException ex) {
+        return ResponseEntity.status(401).body(Map.of(
+            "error", "Unauthorized",
+            "message", ex.getMessage()
+        ));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<?> handleAccessDenied(AccessDeniedException ex) {
+        return ResponseEntity.status(403).body(Map.of(
+            "error", "Forbidden",
+            "message", ex.getMessage()
+        ));
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<?> handleNotFound(EntityNotFoundException ex) {
+        return ResponseEntity.status(404).body(Map.of(
+            "error", "Not Found",
+            "message", ex.getMessage()
+        ));
+    }
+}
+

--- a/src/main/java/kr/or/kosa/snippets/snippetExt/mapper/SnippetExtMapper.java
+++ b/src/main/java/kr/or/kosa/snippets/snippetExt/mapper/SnippetExtMapper.java
@@ -4,6 +4,8 @@ import kr.or.kosa.snippets.snippetExt.model.SnippetExtCreate;
 import kr.or.kosa.snippets.snippetExt.model.SnippetExtUpdate;
 import org.apache.ibatis.annotations.Mapper;
 
+import java.util.Optional;
+
 @Mapper
 public interface SnippetExtMapper {
 
@@ -18,4 +20,6 @@ public interface SnippetExtMapper {
     void deleteSnippet(Long id);
 
     void insertSnippetImg(SnippetExtCreate snippet);
+
+    Optional<Long> findUserIdBySnippetId(Long snippetId);
 }

--- a/src/main/java/kr/or/kosa/snippets/snippetExt/mapper/SnippetExtMapper.java
+++ b/src/main/java/kr/or/kosa/snippets/snippetExt/mapper/SnippetExtMapper.java
@@ -22,4 +22,7 @@ public interface SnippetExtMapper {
     void insertSnippetImg(SnippetExtCreate snippet);
 
     Optional<Long> findUserIdBySnippetId(Long snippetId);
+
+    int countDuplicate(SnippetExtCreate snippet);
+
 }

--- a/src/main/java/kr/or/kosa/snippets/snippetExt/model/SnippetExtCreate.java
+++ b/src/main/java/kr/or/kosa/snippets/snippetExt/model/SnippetExtCreate.java
@@ -6,6 +6,7 @@ import lombok.Data;
 @Data
 public class SnippetExtCreate {
     private Long snippetId;
+    private Long userId;
     private Long colorId;
     private String sourceUrl;
     private SnippetType type;

--- a/src/main/java/kr/or/kosa/snippets/snippetExt/model/SnippetExtCreate.java
+++ b/src/main/java/kr/or/kosa/snippets/snippetExt/model/SnippetExtCreate.java
@@ -1,18 +1,40 @@
 package kr.or.kosa.snippets.snippetExt.model;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import kr.or.kosa.snippets.snippetExt.type.SnippetType;
 import lombok.Data;
 
 @Data
 public class SnippetExtCreate {
-    private Long snippetId;
+
+    private Long snippetId; // 생성 시 필요 없음
+
+    @NotNull(message = "사용자 ID는 필수입니다.")
     private Long userId;
+
     private Long colorId;
+
+    @NotBlank(message = "출처 URL은 필수입니다.")
     private String sourceUrl;
+
+    @NotNull(message = "스니펫 타입은 필수입니다.")
     private SnippetType type;
+
     private String memo;
-    private String content; // text, code
+
+    // TEXT, CODE 공통
+    private String content;
+
+    // CODE 전용
     private String language;
+
+    // IMG 전용
     private String imageUrl;
     private String altText;
+
+    public String getTypeName() {
+        return type != null ? type.name() : null;
+    }
+
 }

--- a/src/main/java/kr/or/kosa/snippets/snippetExt/model/SnippetExtUpdate.java
+++ b/src/main/java/kr/or/kosa/snippets/snippetExt/model/SnippetExtUpdate.java
@@ -5,6 +5,7 @@ import lombok.Data;
 @Data
 public class SnippetExtUpdate {
     private Long snippetId;
+    private Long userId;
     private Long colorId;
     private String memo;
 }

--- a/src/main/java/kr/or/kosa/snippets/snippetExt/service/SnippetExtService.java
+++ b/src/main/java/kr/or/kosa/snippets/snippetExt/service/SnippetExtService.java
@@ -1,12 +1,16 @@
 package kr.or.kosa.snippets.snippetExt.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import kr.or.kosa.snippets.snippetExt.mapper.SnippetExtMapper;
 import kr.or.kosa.snippets.snippetExt.model.SnippetExtCreate;
 import kr.or.kosa.snippets.snippetExt.model.SnippetExtUpdate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -19,7 +23,6 @@ public class SnippetExtService {
     public Long save(SnippetExtCreate snippet) {
         snippetExtMapper.insertSnippet(snippet); // snippets 테이블
 
-        // 2. 스니펫 유형에 따라 분기 저장
         switch (snippet.getType()) {
             case TEXT -> snippetExtMapper.insertSnippetText(snippet);
             case CODE -> snippetExtMapper.insertSnippetCode(snippet);
@@ -29,11 +32,25 @@ public class SnippetExtService {
         return snippet.getSnippetId();
     }
 
-    public void updateSnippet(SnippetExtUpdate snippetUpdate) {
+    public void updateSnippet(SnippetExtUpdate snippetUpdate, Long requesterId) {
+        Long ownerId = snippetExtMapper.findUserIdBySnippetId(snippetUpdate.getSnippetId())
+            .orElseThrow(() -> new EntityNotFoundException("해당 스니펫이 존재하지 않습니다."));
+
+        if (!Objects.equals(requesterId, ownerId)) {
+            throw new AccessDeniedException("수정 권한이 없습니다.");
+        }
+        snippetUpdate.setUserId(requesterId);
         snippetExtMapper.updateSnippet(snippetUpdate);
     }
 
-    public void deleteSnippet(Long id) {
-        snippetExtMapper.deleteSnippet(id);
+    public void deleteSnippet(Long snippetId, Long requesterId) {
+        Long ownerId = snippetExtMapper.findUserIdBySnippetId(snippetId)
+            .orElseThrow(() -> new EntityNotFoundException("삭제할 스니펫이 존재하지 않습니다."));
+
+        if (!Objects.equals(requesterId, ownerId)) {
+            throw new AccessDeniedException("삭제 권한이 없습니다.");
+        }
+
+        snippetExtMapper.deleteSnippet(snippetId);
     }
 }

--- a/src/main/java/kr/or/kosa/snippets/snippetExt/service/SnippetExtService.java
+++ b/src/main/java/kr/or/kosa/snippets/snippetExt/service/SnippetExtService.java
@@ -1,6 +1,7 @@
 package kr.or.kosa.snippets.snippetExt.service;
 
 import jakarta.persistence.EntityNotFoundException;
+import kr.or.kosa.snippets.snippetExt.exception.DuplicateSnippetException;
 import kr.or.kosa.snippets.snippetExt.mapper.SnippetExtMapper;
 import kr.or.kosa.snippets.snippetExt.model.SnippetExtCreate;
 import kr.or.kosa.snippets.snippetExt.model.SnippetExtUpdate;
@@ -19,38 +20,90 @@ public class SnippetExtService {
 
     private final SnippetExtMapper snippetExtMapper;
 
+    // ================================================
+    // public
+    // ================================================
+
     @Transactional
     public Long save(SnippetExtCreate snippet) {
-        snippetExtMapper.insertSnippet(snippet); // snippets 테이블
-
-        switch (snippet.getType()) {
-            case TEXT -> snippetExtMapper.insertSnippetText(snippet);
-            case CODE -> snippetExtMapper.insertSnippetCode(snippet);
-            case IMG -> snippetExtMapper.insertSnippetImg(snippet);
+        if (isDuplicate(snippet)) {
+            throw new DuplicateSnippetException("이미 동일한 스니펫이 존재합니다.");
         }
+
+        validateSnippet(snippet);           // 유효성 검사
+        snippetExtMapper.insertSnippet(snippet); // 공통 삽입
+        insertDetailByType(snippet);        // 타입별 분기 삽입
 
         return snippet.getSnippetId();
     }
 
     public void updateSnippet(SnippetExtUpdate snippetUpdate, Long requesterId) {
-        Long ownerId = snippetExtMapper.findUserIdBySnippetId(snippetUpdate.getSnippetId())
-            .orElseThrow(() -> new EntityNotFoundException("해당 스니펫이 존재하지 않습니다."));
+        Long ownerId = getOwnerIdOrThrow(snippetUpdate.getSnippetId());
+        validateOwnership(ownerId, requesterId, "수정 권한이 없습니다.");
 
-        if (!Objects.equals(requesterId, ownerId)) {
-            throw new AccessDeniedException("수정 권한이 없습니다.");
-        }
         snippetUpdate.setUserId(requesterId);
         snippetExtMapper.updateSnippet(snippetUpdate);
     }
 
     public void deleteSnippet(Long snippetId, Long requesterId) {
-        Long ownerId = snippetExtMapper.findUserIdBySnippetId(snippetId)
-            .orElseThrow(() -> new EntityNotFoundException("삭제할 스니펫이 존재하지 않습니다."));
-
-        if (!Objects.equals(requesterId, ownerId)) {
-            throw new AccessDeniedException("삭제 권한이 없습니다.");
-        }
+        Long ownerId = getOwnerIdOrThrow(snippetId);
+        validateOwnership(ownerId, requesterId, "삭제 권한이 없습니다.");
 
         snippetExtMapper.deleteSnippet(snippetId);
+    }
+
+    // ================================================
+    // private 내부 로직
+    // ================================================
+
+    private boolean isDuplicate(SnippetExtCreate snippet) {
+        return snippetExtMapper.countDuplicate(snippet) > 0;
+    }
+
+    private void validateSnippet(SnippetExtCreate snippet) {
+        switch (snippet.getType()) {
+            case TEXT -> {
+                if (isBlank(snippet.getContent())) {
+                    throw new IllegalArgumentException("TEXT 스니펫은 content가 필수입니다.");
+                }
+            }
+            case CODE -> {
+                if (isBlank(snippet.getContent())) {
+                    throw new IllegalArgumentException("CODE 스니펫은 content가 필수입니다.");
+                }
+                if (isBlank(snippet.getLanguage())) {
+                    throw new IllegalArgumentException("CODE 스니펫은 language가 필수입니다.");
+                }
+            }
+            case IMG -> {
+                if (isBlank(snippet.getImageUrl())) {
+                    throw new IllegalArgumentException("IMG 스니펫은 imageUrl이 필수입니다.");
+                }
+            }
+            default -> throw new IllegalArgumentException("지원하지 않는 스니펫 타입입니다.");
+        }
+    }
+
+    private void insertDetailByType(SnippetExtCreate snippet) {
+        switch (snippet.getType()) {
+            case TEXT -> snippetExtMapper.insertSnippetText(snippet);
+            case CODE -> snippetExtMapper.insertSnippetCode(snippet);
+            case IMG -> snippetExtMapper.insertSnippetImg(snippet);
+        }
+    }
+
+    private Long getOwnerIdOrThrow(Long snippetId) {
+        return snippetExtMapper.findUserIdBySnippetId(snippetId)
+            .orElseThrow(() -> new EntityNotFoundException("해당 스니펫이 존재하지 않습니다."));
+    }
+
+    private void validateOwnership(Long ownerId, Long requesterId, String message) {
+        if (!Objects.equals(requesterId, ownerId)) {
+            throw new AccessDeniedException(message);
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
     }
 }

--- a/src/main/resources/extension/background.js
+++ b/src/main/resources/extension/background.js
@@ -1,36 +1,31 @@
+let userId = null;
+
 chrome.action.onClicked.addListener(async (tab) => {
-    // const loggedIn = await checkLoginStatus();
-    //
-    // if (loggedIn) {
-        // 로그인 O → 사이드바 토글 메시지 전송
+    const isLoggedIn = await checkLoginStatus();
+
+    if (isLoggedIn) {
         chrome.tabs.sendMessage(tab.id, { action: "toggleSidebar" });
-    // } else {
-    //     // 로그인 X → 로그인 페이지로 이동
-    //     chrome.tabs.create({ url: "http://localhost:8090/login" });
-    // }
+    } else {
+        chrome.tabs.create({ url: "http://localhost:8090/login" });
+    }
 });
+
 
 // 로그인 상태 확인 함수 (세션 기반)
 async function checkLoginStatus() {
     try {
         const res = await fetch("http://localhost:8090/api/session-user", {
             method: "GET",
-            credentials: "include",
+            credentials: "include", // 세션 쿠키 포함
         });
 
-        if (res.ok) {
-            const user = await res.json();
-            console.log("로그인됨:", user.username);
-            return true;
-        } else {
-            console.warn("로그인 안됨");
-            return false;
-        }
+        return res.ok; // 200이면 로그인, 401이면 비로그인
     } catch (err) {
         console.error("로그인 확인 실패:", err);
         return false;
     }
 }
+
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // 1. 스니펫 저장 (POST /api/snippets)

--- a/src/main/resources/extension/background.js
+++ b/src/main/resources/extension/background.js
@@ -4,9 +4,9 @@ chrome.action.onClicked.addListener(async (tab) => {
     const isLoggedIn = await checkLoginStatus();
 
     if (isLoggedIn) {
-        chrome.tabs.sendMessage(tab.id, { action: "toggleSidebar" });
+        chrome.tabs.sendMessage(tab.id, {action: "toggleSidebar"});
     } else {
-        chrome.tabs.create({ url: "http://localhost:8090/login" });
+        chrome.tabs.create({url: "http://localhost:8090/login"});
     }
 });
 
@@ -30,32 +30,22 @@ async function checkLoginStatus() {
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // 1. 스니펫 저장 (POST /api/snippets)
     if (message.action === "sendSnippetToServer") {
-        fetch("http://localhost:8090/api/snippets", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(message.payload),
-            credentials: "include",
-        })
-            .then((res) => {
-                if (!res.ok) throw new Error("Server responded with error");
-                return res.json();
-            })
-            .then((data) => {
-                console.log("스니펫 저장 완료:", data);
-                sendResponse({ success: true, snippetId: data.snippetId });
-            })
-            .catch((err) => {
-                console.warn("스니펫 저장 실패:", err.message);
-                sendResponse({ success: false, error: err.message });
-            });
-        return true; // 비동기 응답을 위해 반드시 필요
+        // 디바운스된 저장 함수 호출 (빠른 중복 요청 방지)
+        debouncedSendSnippet(message, (res) => {
+            if (chrome.runtime.lastError) {
+                console.warn("응답 실패:", chrome.runtime.lastError.message);
+            } else {
+                sendResponse(res);
+            }
+        });
+        return true;
     }
 
     // 2. 스니펫 수정 (PATCH /api/snippets/{id})
     if (message.action === "updateSnippet") {
         fetch(`http://localhost:8090/api/snippets/${message.snippetId}`, {
             method: "PATCH",
-            headers: { "Content-Type": "application/json" },
+            headers: {"Content-Type": "application/json"},
             body: JSON.stringify(message.payload),
             credentials: "include",
         })
@@ -65,11 +55,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             })
             .then(() => {
                 console.log("스니펫 수정 완료:", message.snippetId);
-                sendResponse({ success: true });
+                sendResponse({success: true});
             })
             .catch((err) => {
                 console.warn("스니펫 수정 실패:", err.message);
-                sendResponse({ success: false, error: err.message });
+                sendResponse({success: false, error: err.message});
             });
         return true;
     }
@@ -82,12 +72,44 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         })
             .then((res) => {
                 if (!res.ok) throw new Error("Delete failed");
-                sendResponse({ success: true });
+                sendResponse({success: true});
             })
             .catch((err) => {
-                sendResponse({ success: false, error: err.message });
+                sendResponse({success: false, error: err.message});
             });
 
         return true; // async 응답 위해 필요
     }
 });
+
+// debounce 함수 정의 (lodash 없이 사용)
+function debounce(func, delay) {
+    let timeout;
+    return function (...args) {
+        clearTimeout(timeout);
+        timeout = setTimeout(() => func.apply(this, args), delay);
+    };
+}
+
+// 디바운스 적용된 스니펫 저장 함수 (마지막 요청만 처리됨)
+const debouncedSendSnippet = debounce((message, sendResponse) => {
+    fetch("http://localhost:8090/api/snippets", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify(message.payload),
+        credentials: "include",
+    })
+        .then((res) => {
+            if (!res.ok) throw new Error("Server responded with error");
+            return res.json();
+        })
+        .then((data) => {
+            console.log("🟡 디바운스 저장 완료:", data);
+            sendResponse({success: true, snippetId: data.snippetId});
+        })
+        .catch((err) => {
+            console.warn("스니펫 저장 실패:", err.message);
+            sendResponse({success: false, error: err.message});
+        });
+}, 500);
+

--- a/src/main/resources/mapper/snippet-ext-mapper.xml
+++ b/src/main/resources/mapper/snippet-ext-mapper.xml
@@ -23,8 +23,8 @@
     <!--    </resultMap>-->
 
     <insert id="insertSnippet" useGeneratedKeys="true" keyProperty="snippetId">
-        INSERT INTO SNIPPETS (SOURCE_URL, TYPE, COLOR_ID, MEMO)
-        VALUES (#{sourceUrl}, #{type}, #{colorId}, #{memo})
+        INSERT INTO SNIPPETS (SOURCE_URL, TYPE, COLOR_ID, MEMO, USER_ID)
+        VALUES (#{sourceUrl}, #{type}, #{colorId}, #{memo}, #{userId})
     </insert>
 
     <insert id="insertSnippetText">
@@ -54,5 +54,11 @@
         FROM SNIPPETS
         WHERE SNIPPET_ID = #{id}
     </delete>
+
+    <select id="findUserIdBySnippetId" resultType="long">
+        SELECT USER_ID
+        FROM SNIPPETS
+        WHERE SNIPPET_ID = #{snippetId}
+    </select>
 
 </mapper>

--- a/src/main/resources/mapper/snippet-ext-mapper.xml
+++ b/src/main/resources/mapper/snippet-ext-mapper.xml
@@ -61,4 +61,39 @@
         WHERE SNIPPET_ID = #{snippetId}
     </select>
 
+    <select id="countDuplicate" resultType="int">
+        <choose>
+            <when test="typeName == 'TEXT'">
+                SELECT COUNT(1)
+                FROM SNIPPETS s
+                JOIN SNIPPET_TEXTS t ON s.snippet_id = t.snippet_id
+                WHERE s.USER_ID = #{userId}
+                AND s.TYPE = #{typeName}
+                AND s.SOURCE_URL = #{sourceUrl}
+                AND t.CONTENT = #{content}
+            </when>
+            <when test="typeName == 'CODE'">
+                SELECT COUNT(1)
+                FROM SNIPPETS s
+                JOIN SNIPPET_CODES c ON s.snippet_id = c.snippet_id
+                WHERE s.USER_ID = #{userId}
+                AND s.TYPE = #{typeName}
+                AND c.LANGUAGE = #{language}
+                AND c.CONTENT = #{content}
+            </when>
+            <when test="typeName == 'IMG'">
+                SELECT COUNT(1)
+                FROM SNIPPETS s
+                JOIN SNIPPET_IMAGES i ON s.snippet_id = i.snippet_id
+                WHERE s.USER_ID = #{userId}
+                AND s.TYPE = #{typeName}
+                AND i.IMAGE_URL = #{imageUrl}
+            </when>
+            <otherwise>
+                SELECT 0
+            </otherwise>
+        </choose>
+    </select>
+
+
 </mapper>

--- a/src/test/java/kr/or/kosa/snippets/snippetExt/service/SnippetExtServiceTest.java
+++ b/src/test/java/kr/or/kosa/snippets/snippetExt/service/SnippetExtServiceTest.java
@@ -1,0 +1,60 @@
+package kr.or.kosa.snippets.snippetExt.service;
+
+import kr.or.kosa.snippets.snippetExt.exception.DuplicateSnippetException;
+import kr.or.kosa.snippets.snippetExt.mapper.SnippetExtMapper;
+import kr.or.kosa.snippets.snippetExt.model.SnippetExtCreate;
+import kr.or.kosa.snippets.snippetExt.type.SnippetType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class SnippetExtServiceTest {
+
+    private SnippetExtMapper mapper;
+    private SnippetExtService service;
+
+    @BeforeEach
+    void setUp() {
+        mapper = mock(SnippetExtMapper.class);
+        service = new SnippetExtService(mapper);
+    }
+
+    @Test
+    void 중복이_아니면_정상적으로_저장된다() {
+        // given
+        SnippetExtCreate snippet = new SnippetExtCreate();
+        snippet.setUserId(1L);
+        snippet.setType(SnippetType.TEXT);
+        snippet.setContent("Hello");
+        snippet.setSourceUrl("https://example.com");
+
+        when(mapper.countDuplicate(snippet)).thenReturn(0);
+
+        // when
+        service.save(snippet);
+
+        // then
+        verify(mapper).insertSnippet(snippet);       // 저장 호출됨
+        verify(mapper).insertSnippetText(snippet);   // TEXT용 저장 호출됨
+    }
+
+    @Test
+    void 중복이면_예외를_던진다() {
+        // given
+        SnippetExtCreate snippet = new SnippetExtCreate();
+        snippet.setUserId(1L);
+        snippet.setType(SnippetType.TEXT);
+        snippet.setContent("Hello");
+        snippet.setSourceUrl("https://example.com");
+
+        when(mapper.countDuplicate(snippet)).thenReturn(1);
+
+        // when & then
+        assertThrows(DuplicateSnippetException.class, () -> service.save(snippet));
+
+        verify(mapper, never()).insertSnippet(any());
+        verify(mapper, never()).insertSnippetText(any());
+    }
+}

--- a/src/test/java/kr/or/kosa/snippets/snippetExt/service/SnippetExtServiceTest.java
+++ b/src/test/java/kr/or/kosa/snippets/snippetExt/service/SnippetExtServiceTest.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class SnippetExtServiceTest {
-
     private SnippetExtMapper mapper;
     private SnippetExtService service;
 


### PR DESCRIPTION
## 📌 주요 변경 사항

- 🔐 **사용자 인증 및 권한 처리**
  - `@AuthenticationPrincipal`을 통해 로그인 사용자 정보 주입
  - 로그인되지 않은 경우 → `AuthenticationCredentialsNotFoundException` 발생
  - 스니펫 수정/삭제 시 권한 없음 → `AccessDeniedException` 처리
  - 존재하지 않는 스니펫 → `EntityNotFoundException` 처리
  - 공통 예외 처리 클래스 `@RestControllerAdvice(SnippetExceptionHandler)` 구성

- 🛡️ **스니펫 중복 등록 방지**
  - `SnippetExtService`에 중복 검사 로직 추가
  - `DuplicateSnippetException` 정의 및 전역 처리

- ⚙️ **enum 타입 매핑 오류 회피**
  - `SnippetType` → `getTypeName()` 메서드 추가
  - MyBatis XML에서 `type.name` → `typeName`으로 수정

- 🧪 **단위 테스트 추가**
  - 중복 저장 방지 로직에 대한 Mock 기반 테스트 코드 작성

- 🧯 **디바운스 처리**
  - 스니펫 등록 요청 디바운스 적용 (0.5초 내 중복 요청 방지)
  - 서버 응답 지연 시 중복 등록 방지를 위한 검사 로직 필요

---

## 📂 주요 변경 파일

- `SnippetExtService.java`  
- `SnippetApiController.java`  
- `SnippetExceptionHandler.java`  
- `DuplicateSnippetException.java`  
- `snippet-ext-mapper.xml`  
- `SnippetExt.java`  
- `SnippetExtServiceTest.java`
