### PR TITLE
Feat/ip block filter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
 
+
+    implementation 'commons-logging:commons-logging'
     // 단위테스트용 mockito 의존성
     testImplementation 'org.mockito:mockito-core:5.12.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/kr/or/kosa/snippets/SnippetsApplication.java
+++ b/src/main/java/kr/or/kosa/snippets/SnippetsApplication.java
@@ -1,12 +1,19 @@
 package kr.or.kosa.snippets;
 
+import kr.or.kosa.snippets.user.blockIp.IpLocationService;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@MapperScan("kr.or.kosa.snippets")
+@MapperScan(
+        basePackages = "kr.or.kosa.snippets",
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = IpLocationService.class)
+)
+
 @EnableScheduling
 public class SnippetsApplication {
 

--- a/src/main/java/kr/or/kosa/snippets/user/blockIp/BlockedIpLog.java
+++ b/src/main/java/kr/or/kosa/snippets/user/blockIp/BlockedIpLog.java
@@ -1,0 +1,23 @@
+package kr.or.kosa.snippets.user.blockIp;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BlockedIpLog {
+    private Long id;
+    private String ip;
+    private String country;
+    private String city;
+    private String userAgent;
+    private boolean isBot;
+    private LocalDateTime blockedAt;
+    private LocalDateTime unblockAt;
+}

--- a/src/main/java/kr/or/kosa/snippets/user/blockIp/BlockedIpLogApiController.java
+++ b/src/main/java/kr/or/kosa/snippets/user/blockIp/BlockedIpLogApiController.java
@@ -1,0 +1,21 @@
+package kr.or.kosa.snippets.user.blockIp;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class BlockedIpLogApiController {
+
+    private final BlockedIpLogMapper blockedIpLogMapper;
+
+    @GetMapping("/blocked-ips")
+    public List<BlockedIpLog> getBlockedIps() {
+        return blockedIpLogMapper.findAllBlockedIpLogs();
+    }
+}

--- a/src/main/java/kr/or/kosa/snippets/user/blockIp/BlockedIpLogLoader.java
+++ b/src/main/java/kr/or/kosa/snippets/user/blockIp/BlockedIpLogLoader.java
@@ -1,0 +1,27 @@
+package kr.or.kosa.snippets.user.blockIp;
+
+import jakarta.annotation.PostConstruct;
+import kr.or.kosa.snippets.user.loginLog.LoginAttemptService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class BlockedIpLogLoader {
+
+    private final BlockedIpLogMapper blockedIpLogMapper;
+    private final LoginAttemptService loginAttemptService;
+
+    @PostConstruct
+    public void preloadBlockedIps() {
+        List<BlockedIpLog> blockedIps = blockedIpLogMapper.findAllStillBlocked(LocalDateTime.now());
+        for (BlockedIpLog log : blockedIps) {
+            loginAttemptService.restoreBlockedIp(log.getIp(), log.getUnblockAt());
+        }
+    }
+}

--- a/src/main/java/kr/or/kosa/snippets/user/blockIp/BlockedIpLogMapper.java
+++ b/src/main/java/kr/or/kosa/snippets/user/blockIp/BlockedIpLogMapper.java
@@ -1,0 +1,15 @@
+package kr.or.kosa.snippets.user.blockIp;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Mapper
+public interface BlockedIpLogMapper {
+    void insertBlockedIpLog(BlockedIpLog log);
+
+    List<BlockedIpLog> findAllBlockedIpLogs();
+
+    List<BlockedIpLog> findAllStillBlocked(LocalDateTime now);
+}

--- a/src/main/java/kr/or/kosa/snippets/user/blockIp/IpApiLocationService.java
+++ b/src/main/java/kr/or/kosa/snippets/user/blockIp/IpApiLocationService.java
@@ -1,0 +1,33 @@
+package kr.or.kosa.snippets.user.blockIp;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Service
+public class IpApiLocationService implements IpLocationService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Override
+    public String getCountry(String ip) {
+        Map<String, Object> data = getData(ip);
+        return data.getOrDefault("country", "Unknown").toString();
+    }
+
+    @Override
+    public String getCity(String ip) {
+        Map<String, Object> data = getData(ip);
+        return data.getOrDefault("city", "Unknown").toString();
+    }
+
+    private Map<String, Object> getData(String ip) {
+        try {
+            String url = "http://ip-api.com/json/" + ip;
+            return restTemplate.getForObject(url, Map.class);
+        } catch (Exception e) {
+            return Map.of("country", "Unknown", "city", "Unknown");
+        }
+    }
+}

--- a/src/main/java/kr/or/kosa/snippets/user/blockIp/IpLocationService.java
+++ b/src/main/java/kr/or/kosa/snippets/user/blockIp/IpLocationService.java
@@ -1,0 +1,6 @@
+package kr.or.kosa.snippets.user.blockIp;
+
+public interface IpLocationService {
+    String getCountry(String ip);
+    String getCity(String ip);
+}

--- a/src/main/java/kr/or/kosa/snippets/user/config/CustomAuthFailureHandler.java
+++ b/src/main/java/kr/or/kosa/snippets/user/config/CustomAuthFailureHandler.java
@@ -4,6 +4,8 @@ package kr.or.kosa.snippets.user.config;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import kr.or.kosa.snippets.user.loginLog.LoginLogService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.AuthenticationException;
@@ -14,13 +16,19 @@ import java.io.IOException;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class CustomAuthFailureHandler implements AuthenticationFailureHandler {
+
+
+
+    private final LoginLogService loginLogService;
     @Override
     public void onAuthenticationFailure(HttpServletRequest request,
                                         HttpServletResponse response,
                                         AuthenticationException exception)
             throws IOException, ServletException {
-
+        String email = request.getParameter("username"); // 로그인 시도한 이메일
+        loginLogService.logLogin(email, request, false);
         log.warn("로그인 실패: {}", exception.getMessage());
         if (exception instanceof BadCredentialsException) {
             log.warn("비밀번호가 틀렸습니다.");

--- a/src/main/java/kr/or/kosa/snippets/user/config/CustomAuthFailureHandler.java
+++ b/src/main/java/kr/or/kosa/snippets/user/config/CustomAuthFailureHandler.java
@@ -4,6 +4,7 @@ package kr.or.kosa.snippets.user.config;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import kr.or.kosa.snippets.user.loginLog.LoginAttemptService;
 import kr.or.kosa.snippets.user.loginLog.LoginLogService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,16 +21,22 @@ import java.io.IOException;
 public class CustomAuthFailureHandler implements AuthenticationFailureHandler {
 
 
-
+    private final LoginAttemptService loginAttemptService;
     private final LoginLogService loginLogService;
+
     @Override
     public void onAuthenticationFailure(HttpServletRequest request,
                                         HttpServletResponse response,
                                         AuthenticationException exception)
             throws IOException, ServletException {
+
         String email = request.getParameter("username"); // 로그인 시도한 이메일
+        String ip = request.getRemoteAddr();
+
         loginLogService.logLogin(email, request, false);
+        loginAttemptService.recordFailure(ip, request.getHeader("User-Agent"));
         log.warn("로그인 실패: {}", exception.getMessage());
+
         if (exception instanceof BadCredentialsException) {
             log.warn("비밀번호가 틀렸습니다.");
         }

--- a/src/main/java/kr/or/kosa/snippets/user/config/CustomAuthSuccessHandler.java
+++ b/src/main/java/kr/or/kosa/snippets/user/config/CustomAuthSuccessHandler.java
@@ -3,6 +3,7 @@ package kr.or.kosa.snippets.user.config;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import kr.or.kosa.snippets.user.loginLog.LoginAttemptService;
 import kr.or.kosa.snippets.user.loginLog.LoginLogService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -16,7 +17,7 @@ import java.io.IOException;
 public class CustomAuthSuccessHandler implements AuthenticationSuccessHandler {
 
     private final LoginLogService loginLogService;
-
+    private final LoginAttemptService loginAttemptService;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -24,6 +25,7 @@ public class CustomAuthSuccessHandler implements AuthenticationSuccessHandler {
         System.out.println("로그인 성공!");
         System.out.println("이메일: " + authentication.getName());
         loginLogService.logLogin(authentication.getName(), request, true);
+        loginAttemptService.reset(request.getRemoteAddr()); // 차단 초기화
         response.sendRedirect("/");
     }
 }

--- a/src/main/java/kr/or/kosa/snippets/user/config/CustomAuthSuccessHandler.java
+++ b/src/main/java/kr/or/kosa/snippets/user/config/CustomAuthSuccessHandler.java
@@ -3,6 +3,8 @@ package kr.or.kosa.snippets.user.config;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import kr.or.kosa.snippets.user.loginLog.LoginLogService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -10,12 +12,18 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 
 @Component
+@RequiredArgsConstructor
 public class CustomAuthSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final LoginLogService loginLogService;
+
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException, ServletException {
         System.out.println("로그인 성공!");
         System.out.println("이메일: " + authentication.getName());
+        loginLogService.logLogin(authentication.getName(), request, true);
         response.sendRedirect("/");
     }
 }

--- a/src/main/java/kr/or/kosa/snippets/user/config/SecurityConfig.java
+++ b/src/main/java/kr/or/kosa/snippets/user/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package kr.or.kosa.snippets.user.config;
 
+import kr.or.kosa.snippets.user.loginLog.IpBlockFilter;
 import kr.or.kosa.snippets.user.service.CustomOAuth2UserService;
 import kr.or.kosa.snippets.user.service.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -22,6 +24,7 @@ public class SecurityConfig {
 
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final IpBlockFilter  ipBlockFilter;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
@@ -37,13 +40,14 @@ public class SecurityConfig {
                                 "/user/js/**",
                                 "/user/images/**"
                         ).permitAll()
-                        .requestMatchers("/admin/**").hasRole("ADMIN")
+//                        .requestMatchers("/admin/**").hasRole("ADMIN")
                         .requestMatchers("/user/**").hasAnyRole("USER", "ADMIN", "OAUTH2")
                         .requestMatchers("/loginproc").hasRole("USER") // ROLE_OAUTH2 막기
                         .requestMatchers("/changePassword").hasRole("USER") // ROLE_OAUTH2 막기
                         .requestMatchers("/login", "/api/register", "/api/verify-code", "/api/forgot-password").anonymous()
                         .anyRequest().permitAll()
                 )
+                .addFilterBefore(ipBlockFilter, UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(e -> e
                         .accessDeniedHandler(customAccessDeniedHandler))
                 .formLogin(form -> form

--- a/src/main/java/kr/or/kosa/snippets/user/controller/AdminPageController.java
+++ b/src/main/java/kr/or/kosa/snippets/user/controller/AdminPageController.java
@@ -1,0 +1,15 @@
+package kr.or.kosa.snippets.user.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/admin")
+public class AdminPageController {
+
+    @GetMapping("/ip-blocks")
+    public String viewIpBlocks() {
+        return "/user/admin/ip-blocks";
+    }
+}

--- a/src/main/java/kr/or/kosa/snippets/user/loginLog/IpBlockFilter.java
+++ b/src/main/java/kr/or/kosa/snippets/user/loginLog/IpBlockFilter.java
@@ -1,0 +1,46 @@
+package kr.or.kosa.snippets.user.loginLog;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class IpBlockFilter extends GenericFilterBean {
+    private final LoginAttemptService loginAttemptService;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest req = (HttpServletRequest) request;
+        String ip = req.getRemoteAddr();
+
+        // 👇 여기 로그 넣기 (조건문 바로 위)
+        log.info("IP: {}, URI: {}, method: {}", ip, req.getRequestURI(), req.getMethod());
+        log.info("차단 여부: {}", loginAttemptService.isBlocked(ip));
+
+        if ("/loginproc".equals(req.getRequestURI())
+                && "POST".equalsIgnoreCase(req.getMethod())
+                && loginAttemptService.isBlocked(ip)) {
+
+            log.warn("차단된 IP의 로그인 시도: {}", ip);
+            HttpServletResponse res = (HttpServletResponse) response;
+            res.sendRedirect("/login?blocked");
+            return;
+        }
+
+        chain.doFilter(request, response);
+    }
+
+}

--- a/src/main/java/kr/or/kosa/snippets/user/loginLog/LoginAttemptService.java
+++ b/src/main/java/kr/or/kosa/snippets/user/loginLog/LoginAttemptService.java
@@ -1,0 +1,128 @@
+package kr.or.kosa.snippets.user.loginLog;
+
+import jakarta.annotation.PostConstruct;
+import kr.or.kosa.snippets.user.blockIp.BlockedIpLog;
+import kr.or.kosa.snippets.user.blockIp.BlockedIpLogMapper;
+import kr.or.kosa.snippets.user.blockIp.IpLocationService;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@RequiredArgsConstructor
+public class LoginAttemptService {
+
+    private final BlockedIpLogMapper blockedIpLogMapper;
+    private final IpLocationService ipLocationService;
+
+    private static final int MAX_ATTEMPTS = 5;
+    private static final Duration BLOCK_DURATION = Duration.ofDays(5);
+
+    private static final Duration ATTEMPT_INTERVAL = Duration.ofSeconds(5);
+    private static final int MAX_SAME_UA_COUNT = 10;
+
+    // IP별 시도 기록
+    private final Map<String, LoginAttemptInfo> attempts = new ConcurrentHashMap<>();
+
+    // IP별 최근 시도 간격 체크용
+    private final Map<String, AttemptMetadata> ipRequestTimestamps = new ConcurrentHashMap<>();
+
+    // IP + UserAgent 조합 추적
+    private final Map<String, Integer> uaAttempts = new ConcurrentHashMap<>();
+
+    @Getter
+    @AllArgsConstructor
+    private static class LoginAttemptInfo {
+        private final int count;
+        private final LocalDateTime blockedUntil;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private static class AttemptMetadata {
+        private final int count;
+        private final LocalDateTime lastAttempt;
+    }
+
+    public void reset(String ip) {
+        attempts.remove(ip);
+        ipRequestTimestamps.remove(ip);
+        uaAttempts.keySet().removeIf(k -> k.startsWith(ip + "::"));
+    }
+
+    public boolean isBlocked(String ip) {
+        LoginAttemptInfo info = attempts.get(ip);
+        if (info == null) return false;
+
+        if (info.blockedUntil != null && info.blockedUntil.isAfter(LocalDateTime.now())) {
+            return true;
+        }
+
+        if (info.blockedUntil != null && info.blockedUntil.isBefore(LocalDateTime.now())) {
+            attempts.remove(ip);
+        }
+
+        return false;
+    }
+
+    public void recordFailure(String ip, String userAgent) {
+        // 일반 실패 횟수 증가
+        LoginAttemptInfo info = attempts.getOrDefault(ip, new LoginAttemptInfo(0, null));
+        int newCount = info.count + 1;
+        LocalDateTime blockedUntil = null;
+
+        // 1. 시도 간격 감지
+        AttemptMetadata meta = ipRequestTimestamps.getOrDefault(ip, new AttemptMetadata(0, LocalDateTime.MIN));
+        Duration interval = Duration.between(meta.getLastAttempt(), LocalDateTime.now());
+        int fastAttemptCount = (interval.compareTo(ATTEMPT_INTERVAL) <= 0) ? meta.getCount() + 1 : 1;
+        ipRequestTimestamps.put(ip, new AttemptMetadata(fastAttemptCount, LocalDateTime.now()));
+
+        // 2. (IP + UA) 조합 시도 감지
+        String key = ip + "::" + userAgent;
+        int uaCount = uaAttempts.getOrDefault(key, 0) + 1;
+        uaAttempts.put(key, uaCount);
+
+        // 차단 조건 충족 시
+        boolean overBasicFail = newCount >= MAX_ATTEMPTS;
+        boolean abnormalByTime = fastAttemptCount >= MAX_ATTEMPTS;
+        boolean abnormalByUa = uaCount >= MAX_SAME_UA_COUNT;
+
+        if (overBasicFail || abnormalByTime || abnormalByUa) {
+            blockedUntil = LocalDateTime.now().plus(BLOCK_DURATION);
+
+            boolean isBot = isBotUserAgent(userAgent);
+            String country = ipLocationService.getCountry(ip);
+            String city = ipLocationService.getCity(ip);
+
+            BlockedIpLog log = BlockedIpLog.builder()
+                    .ip(ip)
+                    .userAgent(userAgent)
+                    .isBot(isBot)
+                    .blockedAt(LocalDateTime.now())
+                    .unblockAt(blockedUntil)
+                    .country(country)
+                    .city(city)
+                    .build();
+
+            blockedIpLogMapper.insertBlockedIpLog(log);
+        }
+
+        // 갱신
+        attempts.put(ip, new LoginAttemptInfo(newCount, blockedUntil));
+    }
+
+    public void restoreBlockedIp(String ip, LocalDateTime unblockAt) {
+        attempts.put(ip, new LoginAttemptInfo(MAX_ATTEMPTS, unblockAt));
+    }
+
+    private boolean isBotUserAgent(String ua) {
+        if (ua == null) return false;
+        return ua.toLowerCase().matches(".*(bot|spider|crawl|httpclient|wget|curl|python).*");
+    }
+}

--- a/src/main/java/kr/or/kosa/snippets/user/loginLog/LoginLog.java
+++ b/src/main/java/kr/or/kosa/snippets/user/loginLog/LoginLog.java
@@ -1,0 +1,21 @@
+package kr.or.kosa.snippets.user.loginLog;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoginLog {
+    private Long id;
+    private String email;
+    private String ip;
+    private String userAgent;
+    private LocalDateTime loginAt;
+    private boolean success;
+}

--- a/src/main/java/kr/or/kosa/snippets/user/loginLog/LoginLogMapper.java
+++ b/src/main/java/kr/or/kosa/snippets/user/loginLog/LoginLogMapper.java
@@ -1,0 +1,15 @@
+package kr.or.kosa.snippets.user.loginLog;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Mapper
+public interface LoginLogMapper {
+    void insertLoginLog(LoginLog log);
+    void insertLoginLogs(List<LoginLog> logs); // 배치 저장
+
+    void deleteOldLogs(@Param("cutoff") LocalDateTime cutoff);
+}

--- a/src/main/java/kr/or/kosa/snippets/user/loginLog/LoginLogService.java
+++ b/src/main/java/kr/or/kosa/snippets/user/loginLog/LoginLogService.java
@@ -1,0 +1,53 @@
+package kr.or.kosa.snippets.user.loginLog;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LoginLogService {
+    private final LoginLogMapper loginLogMapper;
+    private final Queue<LoginLog> logBuffer = new ConcurrentLinkedQueue<>();
+
+    public void logLogin(String email, HttpServletRequest request, boolean success) {
+        LoginLog log = LoginLog.builder()
+                .email(email)
+                .ip(request.getRemoteAddr())
+                .userAgent(request.getHeader("User-Agent"))
+                .loginAt(LocalDateTime.now())
+                .success(success)
+                .build();
+
+        logBuffer.add(log);
+    }
+
+    @Scheduled(fixedRate = 1 * 60 * 1000) // 5분마다
+    public void flushLogsToDb() {
+        List<LoginLog> logs = new ArrayList<>();
+        while (!logBuffer.isEmpty()) {
+            logs.add(logBuffer.poll());
+        }
+
+        if (!logs.isEmpty()) {
+            loginLogMapper.insertLoginLogs(logs);
+            log.info("로그 {}건 DB 저장됨", logs.size());
+        }
+    }
+
+    @Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시
+    public void deleteOldLogs() {
+        LocalDateTime cutoff = LocalDateTime.now().minusDays(7);
+        loginLogMapper.deleteOldLogs(cutoff);
+        log.info("1주일 지난 로그인 로그 삭제 (기준: {})", cutoff);
+    }
+}

--- a/src/main/resources/mapper/BlockedIpLogMapper.xml
+++ b/src/main/resources/mapper/BlockedIpLogMapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="kr.or.kosa.snippets.user.blockIp.BlockedIpLogMapper">
+
+    <insert id="insertBlockedIpLog">
+        INSERT INTO blocked_ip_log
+            (ip, country, city, user_agent, is_bot, blocked_at, unblock_at)
+        VALUES
+            (#{ip}, #{country}, #{city}, #{userAgent}, #{isBot}, #{blockedAt}, #{unblockAt})
+    </insert>
+
+    <select id="findAllBlockedIpLogs" resultType="kr.or.kosa.snippets.user.blockIp.BlockedIpLog">
+        SELECT * FROM blocked_ip_log
+    </select>
+    <select id="findAllStillBlocked" resultType="kr.or.kosa.snippets.user.blockIp.BlockedIpLog">
+        SELECT * FROM blocked_ip_log
+        WHERE unblock_at > NOW()
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/LoginLogMapper.xml
+++ b/src/main/resources/mapper/LoginLogMapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="kr.or.kosa.snippets.user.loginLog.LoginLogMapper">
+
+    <insert id="insertLoginLog">
+        INSERT INTO login_log (email, ip, user_agent, login_at, success)
+        VALUES (#{email}, #{ip}, #{userAgent}, #{loginAt}, #{success})
+    </insert>
+
+    <insert id="insertLoginLogs">
+        INSERT INTO login_log (email, ip, user_agent, login_at, success)
+        VALUES
+        <foreach collection="list" item="log" separator=",">
+            (#{log.email}, #{log.ip}, #{log.userAgent}, #{log.loginAt}, #{log.success})
+        </foreach>
+    </insert>
+
+    <delete id="deleteOldLogs">
+        DELETE FROM login_log
+        WHERE login_at &lt; #{cutoff}
+    </delete>
+
+</mapper>

--- a/src/main/resources/templates/user/admin/ip-blocks.html
+++ b/src/main/resources/templates/user/admin/ip-blocks.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+	<meta charset="UTF-8">
+	<title>IP 차단 로그</title>
+	<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+	<style>
+		body {
+			font-family: Arial, sans-serif;
+			padding: 2rem;
+			background-color: #f9f9f9;
+		}
+
+		h1, h2 {
+			text-align: center;
+			color: #333;
+		}
+
+		table {
+			width: 100%;
+			border-collapse: collapse;
+			margin-top: 1rem;
+			background-color: #fff;
+			box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+		}
+
+		th, td {
+			padding: 12px;
+			border-bottom: 1px solid #ddd;
+			text-align: center;
+		}
+
+		th {
+			background-color: #f0f0f0;
+			color: #555;
+		}
+
+		td {
+			font-size: 0.95rem;
+		}
+
+		canvas {
+			max-width: 600px;
+			margin: 2rem auto;
+			display: block;
+		}
+	</style>
+</head>
+<body>
+<h1>IP 차단 로그</h1>
+
+<table>
+	<thead>
+	<tr>
+		<th>IP</th>
+		<th>국가</th>
+		<th>도시</th>
+		<th>유저 에이전트</th>
+		<th>Bot 여부</th>
+		<th>차단 시간</th>
+	</tr>
+	</thead>
+	<tbody id="logTableBody"></tbody>
+</table>
+
+<h2>차단 국가 분포</h2>
+<canvas id="countryChart"></canvas>
+
+<h2>Bot vs Browser</h2>
+<canvas id="typeChart"></canvas>
+
+<script>
+	async function fetchBlockedIps() {
+		const res = await fetch("/api/admin/blocked-ips");
+		const data = await res.json();
+
+		const tbody = document.getElementById("logTableBody");
+		tbody.innerHTML = "";
+
+		const countryCounts = {};
+		let botCount = 0, browserCount = 0;
+
+		data.forEach(log => {
+			const row = `
+          <tr>
+            <td>${log.ip}</td>
+            <td>${log.country || 'N/A'}</td>
+            <td>${log.city || 'N/A'}</td>
+            <td>${log.userAgent || 'N/A'}</td>
+            <td>${log.bot ? "✅" : "❌"}</td>
+            <td>${log.blockedAt}</td>
+          </tr>`;
+			tbody.insertAdjacentHTML("beforeend", row);
+
+			const country = log.country || "Unknown";
+			countryCounts[country] = (countryCounts[country] || 0) + 1;
+			log.bot ? botCount++ : browserCount++;
+		});
+
+		updateCharts(countryCounts, botCount, browserCount);
+	}
+
+	let countryChart, typeChart;
+
+	function updateCharts(countryCounts, botCount, browserCount) {
+		const countries = Object.keys(countryCounts);
+		const counts = Object.values(countryCounts);
+
+		if (!countryChart) {
+			countryChart = new Chart(document.getElementById('countryChart'), {
+				type: 'bar',
+				data: {
+					labels: countries,
+					datasets: [{
+						label: 'Blocked IPs by Country',
+						data: counts,
+						borderWidth: 1
+					}]
+				},
+				options: {
+					responsive: true,
+					scales: {
+						y: {
+							beginAtZero: true
+						}
+					}
+				}
+			});
+		} else {
+			countryChart.data.labels = countries;
+			countryChart.data.datasets[0].data = counts;
+			countryChart.update();
+		}
+
+		if (!typeChart) {
+			typeChart = new Chart(document.getElementById('typeChart'), {
+				type: 'pie',
+				data: {
+					labels: ['Bot', 'Browser'],
+					datasets: [{
+						data: [botCount, browserCount],
+						backgroundColor: ['#ff4d4f', '#4e91f9']
+					}]
+				},
+				options: {
+					responsive: true
+				}
+			});
+		} else {
+			typeChart.data.datasets[0].data = [botCount, browserCount];
+			typeChart.update();
+		}
+	}
+
+	setInterval(fetchBlockedIps, 5000);
+	fetchBlockedIps(); // 초기 로딩
+</script>
+</body>
+</html>


### PR DESCRIPTION


### 🚀 비정상 로그인 시도 감지 및 차단 시스템 구현


#### ✅ 구현 내용

* **LoginAttemptService**

  * IP별 로그인 실패 횟수 및 마지막 시각 추적
  * IP + User-Agent 기반 비정상 시도 감지
  * 임계치 초과 시 메모리 및 DB에 차단 정보 저장
  * ip-api.com 호출을 통해 국가 / 도시 정보 수집
  * Bot 판별 로직 적용 (User-Agent 기반)

* **BlockedIpLogMapper & Entity**

  * 차단 로그를 DB에 저장
  * 차단 시작 시각과 해제 시각 기록

* **IpBlockFilter**

  * 요청마다 현재 IP 차단 여부 확인
  * 차단된 IP일 경우 요청 차단 처리

* **Admin 차단 현황 페이지**

  * `/api/admin/blocked-ips` API 제공
  * Chart.js로 국가 분포 및 Bot/Browser 비율 시각화
  * 5초 주기로 실시간 갱신
  * 단, 하루 45회 제한 ( 무료 API )

---

#### 🛠 기타

* RestTemplate 기반 외부 API 호출 예외 처리 추가
* ip-api.com 무료 플랜에 따라 `country`, `city`가 `Unknown`으로 나올 수 있음

---
#### 🔒 보안 고려사항

* Bot 여부 식별을 통한 대응 체계 마련
* 향후 Google reCAPTCHA / Cloudflare 연계 가능성 고려


