### PR TITLE
Feat/tag

### DIFF
--- a/src/main/java/kr/or/kosa/snippets/tag/controller/TagController.java
+++ b/src/main/java/kr/or/kosa/snippets/tag/controller/TagController.java
@@ -1,6 +1,7 @@
 package kr.or.kosa.snippets.tag.controller;
 
 import jakarta.servlet.http.HttpSession;
+import kr.or.kosa.snippets.basic.model.Snippets;
 import kr.or.kosa.snippets.basic.service.SnippetService;
 import kr.or.kosa.snippets.tag.model.TagItem;
 import kr.or.kosa.snippets.tag.service.TagService;
@@ -201,5 +202,23 @@ public class TagController {
             response.put("error", "태그 삭제에 실패했습니다. 권한을 확인해주세요");
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
         }
+    }
+
+    // 특정 태그의 스니펫 조회
+    @GetMapping("/{tagId}/snippets")
+    public ResponseEntity<List<Snippets>> getSnippetsByTagId(@PathVariable Long tagId,
+                                                             @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = requireLogin(userDetails);
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        // 태그 소유권 확인
+        if (!tagService.isTagOwnedByUser(tagId, userId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        List<Snippets> snippets = tagService.getSnippetsByTagId(tagId);
+        return ResponseEntity.ok(snippets != null ? snippets : new ArrayList<>());
     }
 }

--- a/src/main/java/kr/or/kosa/snippets/tag/controller/TagController.java
+++ b/src/main/java/kr/or/kosa/snippets/tag/controller/TagController.java
@@ -4,10 +4,12 @@ import jakarta.servlet.http.HttpSession;
 import kr.or.kosa.snippets.basic.service.SnippetService;
 import kr.or.kosa.snippets.tag.model.TagItem;
 import kr.or.kosa.snippets.tag.service.TagService;
+import kr.or.kosa.snippets.user.service.CustomUserDetails;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
@@ -26,10 +28,21 @@ public class TagController {
     @Autowired
     private SnippetService snippetService;
 
+    private Long requireLogin(CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            log.warn("사용자 인증 정보가 없습니다.");
+            return null;
+        }
+        return userDetails.getUserId();
+    }
+
     // 현재 사용자의 모든 태그 조회
     @GetMapping("/my-tags")
-    public ResponseEntity<List<TagItem>> getMyTags(HttpSession session) {
-        Long userId = (Long) session.getAttribute("userId");
+    public ResponseEntity<List<TagItem>> getMyTags(@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+//        Long userId = (Long) session.getAttribute("userId");
+        Long userId = requireLogin(userDetails);
+
         if (userId == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
@@ -59,8 +72,10 @@ public class TagController {
     // 새 태그 생성 (현재 사용자)
     @PostMapping
     public ResponseEntity<Map<String, Object>> createTag(@RequestBody Map<String, String> request,
-                                                         HttpSession session) {
-        Long userId = (Long) session.getAttribute("userId");
+                                                         @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Long userId = requireLogin(userDetails);
+//        Long userId = (Long) session.getAttribute("userId");
         if (userId == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
@@ -98,8 +113,10 @@ public class TagController {
     @PostMapping("/snippet/{snippetId}/tag/{tagId}")
     public ResponseEntity<Map<String, Object>> addTagToSnippet(@PathVariable Long snippetId,
                                                                @PathVariable Long tagId,
-                                                               HttpSession session) {
-        Long userId = (Long) session.getAttribute("userId");
+                                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
+//        Long userId = (Long) session.getAttribute("userId");
+        Long userId = requireLogin(userDetails);
+
         if (userId == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
@@ -142,8 +159,10 @@ public class TagController {
     @DeleteMapping("/snippet/{snippetId}/tag/{tagId}")
     public ResponseEntity<Map<String, Object>> removeTagFromSnippet(@PathVariable Long snippetId,
                                                                     @PathVariable Long tagId,
-                                                                    HttpSession session) {
-        Long userId = (Long) session.getAttribute("userId");
+                                                                    @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Long userId = requireLogin(userDetails);
+//        Long userId = (Long) session.getAttribute("userId");
         if (userId == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
@@ -164,8 +183,9 @@ public class TagController {
     // 태그 삭제 (사용자 권한 확인)
     @DeleteMapping("/{tagId}")
     public ResponseEntity<Map<String, Object>> deleteTag(@PathVariable Long tagId,
-                                                         HttpSession session) {
-        Long userId = (Long) session.getAttribute("userId");
+                                                         @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = requireLogin(userDetails);
+//        Long userId = (Long) session.getAttribute("userId");
         if (userId == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }

--- a/src/main/java/kr/or/kosa/snippets/tag/controller/TagPageController.java
+++ b/src/main/java/kr/or/kosa/snippets/tag/controller/TagPageController.java
@@ -36,7 +36,11 @@ public class TagPageController {
      * URL: /tags/manager
      */
     @GetMapping("/manager")
-    public String showTagManager() {
+    public String showTagManager(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
+        Long userId = requireLogin(userDetails);
+        log.info("태그 관리 페이지 접근 - 사용자 ID: {}", userId);
+
+        model.addAttribute("currentUserId", userId);
         return "tag/tag-manager";
     }
 
@@ -46,14 +50,13 @@ public class TagPageController {
      */
     @GetMapping("/snippet-tag")
     public String showSnippetTagManagement(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
-
         try {
             Long currentId = requireLogin(userDetails);
             log.info("스니펫 태그 관리 페이지 접근 - 사용자 ID: {}", currentId);
 
             if (currentId == null) {
                 // 로그인되지 않은 경우 빈 데이터로 설정
-                model.addAttribute("snippets", new ArrayList<>());
+                model.addAttribute("snippetList", new ArrayList<>());  // snippets -> snippetList로 변경
                 model.addAttribute("tags", new ArrayList<>());
                 model.addAttribute("userId", null);
                 model.addAttribute("error", "로그인이 필요합니다.");
@@ -69,13 +72,13 @@ public class TagPageController {
             log.info("사용자 {}가 만든 태그 수: {}", currentId, myTags != null ? myTags.size() : 0);
 
             // null 체크 및 기본값 설정
-            model.addAttribute("snippets", mySnippets != null ? mySnippets : new ArrayList<>());
+            model.addAttribute("snippetList", mySnippets != null ? mySnippets : new ArrayList<>());  // snippets -> snippetList로 변경
             model.addAttribute("tags", myTags != null ? myTags : new ArrayList<>());
             model.addAttribute("userId", currentId);
 
         } catch (Exception e) {
             log.error("스니펫/태그 조회 중 오류 발생", e);
-            model.addAttribute("snippets", new ArrayList<>());
+            model.addAttribute("snippetList", new ArrayList<>());  // snippets -> snippetList로 변경
             model.addAttribute("tags", new ArrayList<>());
             model.addAttribute("userId", null);
             model.addAttribute("error", "데이터를 불러오는 중 오류가 발생했습니다: " + e.getMessage());

--- a/src/main/java/kr/or/kosa/snippets/tag/mapper/TagMapper.java
+++ b/src/main/java/kr/or/kosa/snippets/tag/mapper/TagMapper.java
@@ -27,7 +27,7 @@ public interface TagMapper {
     // 사용자별 태그 생성 (user_id 포함)
     @Insert("INSERT INTO tags (user_id, name) VALUES (#{userId}, #{name})")
     @Options(useGeneratedKeys = true, keyProperty = "tagId")
-    int insertTag(@Param("userId") Long userId, @Param("name") String name);
+    int insertTag(TagItem tagItem);
 
     // 특정 스니펫의 태그 조회
     @Select("SELECT t.* FROM tags t INNER JOIN snippet_tags st ON t.tag_id = st.tag_id WHERE st.snippet_id = #{snippetId}")

--- a/src/main/java/kr/or/kosa/snippets/tag/service/TagService.java
+++ b/src/main/java/kr/or/kosa/snippets/tag/service/TagService.java
@@ -47,9 +47,8 @@ public class TagService {
             throw new IllegalArgumentException("이미 존재하는 태그입니다: " + name);
         }
 
-        TagItem tag = new TagItem(userId, name);
-        int result = tagMapper.insertTag(userId, name);
-
+        TagItem newTag = new TagItem(userId, name);
+        int result = tagMapper.insertTag(newTag);
         if (result > 0) {
             // 생성된 태그 정보 반환 (auto-generated key 포함)
             return tagMapper.selectTagByUserIdAndName(userId, name);

--- a/src/main/resources/static/tag/css/tag-manager.css
+++ b/src/main/resources/static/tag/css/tag-manager.css
@@ -334,3 +334,98 @@ h1 {
         padding: 15px;
     }
 }
+
+/* 모달 스타일 추가 */
+.modal {
+    position: fixed;
+    z-index: 2000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.modal-content {
+    background-color: white;
+    border-radius: 10px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    max-width: 400px;
+    width: 90%;
+    max-height: 80%;
+    overflow-y: auto;
+}
+
+.modal-header {
+    padding: 20px 20px 10px 20px;
+    border-bottom: 1px solid #e0e0e0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.modal-header h3 {
+    margin: 0;
+    color: #333;
+}
+
+.modal-close {
+    font-size: 24px;
+    cursor: pointer;
+    color: #999;
+}
+
+.modal-close:hover {
+    color: #333;
+}
+
+.modal-body {
+    padding: 20px;
+}
+
+.warning-text {
+    color: #e74c3c;
+    font-size: 14px;
+    margin-top: 10px;
+}
+
+.modal-footer {
+    padding: 10px 20px 20px 20px;
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+}
+
+.btn-danger {
+    background: #e74c3c;
+    color: white;
+}
+
+.btn-danger:hover {
+    background: #c0392b;
+}
+
+.btn-secondary {
+    background: #95a5a6;
+    color: white;
+}
+
+.btn-secondary:hover {
+    background: #7f8c8d;
+}
+
+.tag-delete-inline {
+    margin-left: 8px;
+    cursor: pointer;
+    font-weight: bold;
+    opacity: 0.7;
+    color: #fff;
+}
+
+.tag-delete-inline:hover {
+    opacity: 1;
+    color: #ff6b6b;
+}

--- a/src/main/resources/static/tag/js/snippet-tags.js
+++ b/src/main/resources/static/tag/js/snippet-tags.js
@@ -1,631 +1,631 @@
-// $(document).ready(function () {
-//     // 전역 변수 선언
-//     let allSnippets = [];
-//     let allTags = [];
-//     let snippetTags = {}; // snippetId -> tags array
-//
-//     // 페이지 로드시 데이터 가져오기
-//     loadInitialData();
-//
-//     // 검색 기능
-//     $('#snippetSearch').on('input', function () {
-//         const keyword = $(this).val().toLowerCase();
-//         filterSnippets(keyword);
-//     });
-//
-//     // 태그 입력 이벤트 (동적으로 생성되는 요소용)
-//     $(document).on('input', '.tag-input', function () {
-//         const input = $(this);
-//         const keyword = input.val().trim();
-//         const autocompleteList = input.siblings('.autocomplete-list');
-//
-//         if (keyword.length > 0) {
-//             const filteredTags = allTags.filter(tag =>
-//                 tag.name.toLowerCase().includes(keyword.toLowerCase())
-//             );
-//             showAutocomplete(autocompleteList, filteredTags);
-//         } else {
-//             autocompleteList.hide();
-//         }
-//     });
-//
-//     // 태그 입력 키보드 이벤트
-//     $(document).on('keydown', '.tag-input', function (e) {
-//         const input = $(this);
-//         const autocompleteList = input.siblings('.autocomplete-list');
-//         const items = autocompleteList.find('.autocomplete-item');
-//         const selectedItem = items.filter('.selected');
-//
-//         if (e.key === 'ArrowDown') {
-//             e.preventDefault();
-//             if (selectedItem.length === 0) {
-//                 items.first().addClass('selected');
-//             } else {
-//                 selectedItem.removeClass('selected');
-//                 const next = selectedItem.next();
-//                 if (next.length > 0) {
-//                     next.addClass('selected');
-//                 } else {
-//                     items.first().addClass('selected');
-//                 }
-//             }
-//         } else if (e.key === 'ArrowUp') {
-//             e.preventDefault();
-//             if (selectedItem.length === 0) {
-//                 items.last().addClass('selected');
-//             } else {
-//                 selectedItem.removeClass('selected');
-//                 const prev = selectedItem.prev();
-//                 if (prev.length > 0) {
-//                     prev.addClass('selected');
-//                 } else {
-//                     items.last().addClass('selected');
-//                 }
-//             }
-//         } else if (e.key === 'Enter') {
-//             e.preventDefault();
-//             if (selectedItem.length > 0) {
-//                 const tagName = selectedItem.text();
-//                 addTagToSnippet(input, tagName);
-//             } else {
-//                 const tagName = input.val().trim();
-//                 if (tagName) {
-//                     addTagToSnippet(input, tagName);
-//                 }
-//             }
-//         } else if (e.key === 'Escape') {
-//             autocompleteList.hide();
-//         }
-//     });
-//
-//     // 자동완성 클릭
-//     $(document).on('click', '.autocomplete-item', function () {
-//         const tagName = $(this).text();
-//         const input = $(this).closest('.tag-input-container').find('.tag-input');
-//         addTagToSnippet(input, tagName);
-//     });
-//
-//     // 태그 제거
-//     $(document).on('click', '.tag-remove', function (e) {
-//         e.preventDefault();
-//         const tagElement = $(this).closest('.tag-item');
-//         const tagName = tagElement.text().replace('×', '').trim();
-//         const snippetId = $(this).closest('.snippet-card').data('snippet-id');
-//
-//         removeTagFromSnippet(snippetId, tagName, tagElement);
-//     });
+ $(document).ready(function () {
+     // 전역 변수 선언
+     let allSnippets = [];
+     let allTags = [];
+     let snippetTags = {}; // snippetId -> tags array
 
-    // // 함수들
-    // function loadInitialData() {
-    //     // 모든 태그 로드
-    //     $.ajax({
-    //         url: /*[[@{/api/tag}]]*/ '/api/tag',
-    //         method: 'GET',
-    //         success: function (tags) {
-    //             console.log('모든 태그 로드 성공:', tags);
-    //             allTags = tags || [];
-    //         },
-    //         error: function (xhr) {
-    //             console.error('태그 목록 로드 실패:', xhr.status);
-    //             allTags = [];
-    //             showError('태그 목록을 불러오는데 실패했습니다.');
-    //         },
-    //         complete: function () {
-    //             // 태그 로드 후 스니펫 로드
-    //             loadSnippets();
-    //         }
-    //     });
-    // }
+     // 페이지 로드시 데이터 가져오기
+     loadInitialData();
 
-    // function loadSnippets() {
-    //     console.log('===== 스니펫 로드 시작 =====');
-    //
-    //     $.ajax({
-    //         url: /*[[@{/api/snippet}]]*/ '/api/snippet',
-    //         method: 'GET',
-    //         success: function(snippets) {
-    //             console.log('스니펫 API 호출 성공');
-    //
-    //             // 응답 데이터 구조 확인
-    //             console.log('응답 데이터 타입:', typeof snippets);
-    //             console.log('응답이 배열인가?', Array.isArray(snippets));
-    //
-    //             // 응답에서 배열 데이터 추출
-    //             if (!Array.isArray(snippets)) {
-    //                 console.log('응답이 배열이 아님. 변환 시도...');
-    //                 if (snippets && typeof snippets === 'object') {
-    //                     if (snippets.content && Array.isArray(snippets.content)) {
-    //                         snippets = snippets.content;
-    //                     }
-    //                 }
-    //             }
-    //
-    //             // 데이터 샘플 확인
-    //             if (Array.isArray(snippets) && snippets.length > 0) {
-    //                 console.log('첫 번째 스니펫 구조:', snippets[0]);
-    //             }
-    //
-    //             // 필드 정규화 및 유효한 스니펫 필터링
-    //             allSnippets = [];
-    //             if (Array.isArray(snippets)) {
-    //                 // 간단히 원본 데이터를 사용
-    //                 allSnippets = snippets.filter(snippet => snippet !== null && snippet !== undefined);
-    //
-    //                 // 디버깅을 위해 첫 몇 개 스니펫의 ID 출력
-    //                 allSnippets.slice(0, 3).forEach((snippet, index) => {
-    //                     console.log(`스니펫 ${index}의 ID(snippetId): ${snippet.snippetId}`);
-    //                 });
-    //             }
-    //
-    //             console.log('처리된 스니펫 수:', allSnippets.length);
-    //
-    //             // 필터링 후에도 스니펫이 없으면 더미 데이터 사용
-    //             if (allSnippets.length === 0) {
-    //                 console.log('스니펫이 없어 더미 데이터를 사용합니다.');
-    //                 allSnippets = getDummySnippets();
-    //             }
-    //
-    //             // 태그 로드 시작
-    //             loadSnippetTags();
-    //         },
-    //         error: function(xhr, status, error) {
-    //             console.error('스니펫 로드 실패:', error);
-    //             console.log('에러 응답:', xhr.responseText);
-    //
-    //             console.log('더미 데이터 사용');
-    //             allSnippets = getDummySnippets();
-    //
-    //             // 태그 로드 시작
-    //             loadSnippetTags();
-    //         }
-    //     });
-    // }
+     // 검색 기능
+     $('#snippetSearch').on('input', function () {
+         const keyword = $(this).val().toLowerCase();
+         filterSnippets(keyword);
+     });
 
-    // // 태그 로드 함수
-    // function loadSnippetTags(focusSnippetId) {
-    //     console.log("모든 스니펫 태그 로드 시작");
-    //     if (!allSnippets || allSnippets.length === 0) {
-    //         console.log('로드할 스니펫이 없습니다.');
-    //         displaySnippets([], focusSnippetId);
-    //         return;
-    //     }
-    //
-    //     console.log('스니펫 태그 로드 시작 - 총 스니펫 수:', allSnippets.length);
-    //
-    //     let loaded = 0;
-    //     const totalSnippets = allSnippets.length;
-    //
-    //     // 모든 스니펫의 태그 초기화
-    //     allSnippets.forEach(snippet => {
-    //         const snippetId = snippet.snippetId;
-    //         console.log(`스니펫 태그 초기화, ID: ${snippetId}`);
-    //         snippetTags[snippetId] = [];
-    //     });
+     // 태그 입력 이벤트 (동적으로 생성되는 요소용)
+     $(document).on('input', '.tag-input', function () {
+         const input = $(this);
+         const keyword = input.val().trim();
+         const autocompleteList = input.siblings('.autocomplete-list');
 
-        // // 태그 로드
-        // allSnippets.forEach((snippet, index) => {
-        //     const snippetId = snippet.snippetId;
-        //     console.log(`스니펫 ${index}의 태그 로드, ID: ${snippetId}`);
-    //
-    //         if (!snippetId) {
-    //             console.error(`스니펫 ${index}에 유효한 ID가 없습니다:`, snippet);
-    //             loaded++;
-    //             checkAllLoaded();
-    //             return;
-    //         }
-    //
-    //         const apiUrl = /*[[@{/api/tag/snippets/}]]*/ '/api/tag/snippets/' + snippetId;
-    //         console.log('태그 API URL:', apiUrl);
-    //
-    //         $.ajax({
-    //             url: apiUrl,
-    //             method: 'GET',
-    //             success: function(tags) {
-    //                 console.log('스니펫 ID - '+snippetId+'의 태그 로드 성공:', tags);
-    //                 if (Array.isArray(tags)) {
-    //                     snippetTags[snippetId] = tags;
-    //                 } else {
-    //                     console.warn(`스니펫 ID ${snippetId}의 태그 응답이 배열이 아님:`, tags);
-    //                     snippetTags[snippetId] = [];
-    //                 }
-    //             },
-    //             error: function(xhr, status, error) {
-    //                 console.error(`스니펫 ID ${snippetId}의 태그 로드 실패:`, {
-    //                     status: xhr.status,
-    //                     error: error
-    //                 });
-    //                 snippetTags[snippetId] = [];
-    //             },
-    //             complete: function() {
-    //                 loaded++;
-    //                 console.log(`태그 로드 진행 상황: ${loaded}/${totalSnippets}`);
-    //                 checkAllLoaded();
-    //             }
-    //         });
-    //     });
-    //
-    //     // 모든 태그 로드 완료 확인
-    //     function checkAllLoaded() {
-    //         if (loaded >= totalSnippets) {
-    //             console.log('모든 스니펫의 태그 로드 완료');
-    //             displaySnippets(allSnippets, focusSnippetId);
-    //         }
-    //     }
-    //
-    //     // 안전장치
-    //     setTimeout(function() {
-    //         if (loaded < totalSnippets) {
-    //             console.warn(`태그 로드 타임아웃: ${loaded}/${totalSnippets} 완료`);
-    //             displaySnippets(allSnippets, focusSnippetId);
-    //         }
-    //     }, 5000);
-    // }
-    //
-    // // 더미 스니펫 데이터
-    // function getDummySnippets() {
-    //     const dummySnippets = [
-    //         {
-    //             snippetId: 1,
-    //             title: 'JavaScript 배열 맵',
-    //             content: 'const numbers = [1, 2, 3, 4, 5];\nconst doubled = numbers.map(num => num * 2);',
-    //             language: 'javascript',
-    //             type: 'code',
-    //             createdAt: '2023-02-01',
-    //             memo: 'JavaScript 배열 맵 함수 예제'
-    //         },
-    //         {
-    //             snippetId: 2,
-    //             title: 'React Hook 예제',
-    //             content: 'import React, { useState } from "react";\n\nfunction Counter() {\n  const [count, setCount] = useState(0);\n  return <div>{count}</div>;\n}',
-    //             language: 'jsx',
-    //             type: 'code',
-    //             createdAt: '2023-02-03',
-    //             memo: 'React useState 훅 사용법'
-    //         },
-    //         {
-    //             snippetId: 3,
-    //             title: 'Date 포맷팅',
-    //             content: 'function formatDate(date) {\n  return date.toISOString().split("T")[0];\n}',
-    //             language: 'javascript',
-    //             type: 'code',
-    //             createdAt: '2023-02-05',
-    //             memo: '날짜 포맷팅 유틸리티 함수'
-    //         }
-    //     ];
-    //
-    //     console.log('더미 스니펫 생성:', dummySnippets.length);
-    //     return dummySnippets;
-    // }
-    //
-    // // 스니펫 표시 함수
-    // function displaySnippets(snippets, focusSnippetId) {
-    //     const container = $('#snippetsContainer');
-    //     container.empty();
-    //
-    //     if (snippets.length === 0) {
-    //         container.html('<div class="loading">표시할 스니펫이 없습니다.</div>');
-    //         return;
-    //     }
-    //
-    //     snippets.forEach(snippet => {
-    //         const snippetCard = createSnippetCard(snippet);
-    //         container.append(snippetCard);
-    //     });
-    //
-    //     // 포커스 설정 (지정된 스니펫 ID가 있는 경우)
-    //     if (focusSnippetId) {
-    //         console.log(`지정된 스니펫 ID ${focusSnippetId}로 포커스 이동 시도`);
-    //
-    //         // 약간의 지연을 두고 포커스 설정 (DOM이 완전히 렌더링된 후)
-    //         setTimeout(function() {
-    //             const card = $(`.snippet-card[data-snippet-id="${focusSnippetId}"]`);
-    //             if (card.length > 0) {
-    //                 console.log(`스니펫 ID ${focusSnippetId}의 카드를 찾음`);
-    //
-    //                 // 입력 필드에 포커스
-    //                 const inputField = card.find('.tag-input');
-    //                 if (inputField.length > 0) {
-    //                     // 카드가 화면에 보이도록 스크롤
-    //                     $('html, body').animate({
-    //                         scrollTop: card.offset().top - 100 // 상단에서 100px 위치에 스크롤
-    //                     }, 300);
-    //
-    //                     // 포커스 설정
-    //                     inputField.focus();
-    //                     console.log(`스니펫 ID ${focusSnippetId}의 태그 입력 필드에 포커스 설정 완료`);
-    //                 } else {
-    //                     console.warn(`스니펫 ID ${focusSnippetId}의 태그 입력 필드를 찾을 수 없음`);
-    //                 }
-    //             } else {
-    //                 console.warn(`스니펫 ID ${focusSnippetId}의 카드를 찾을 수 없음`);
-    //             }
-    //         }, 300);
-    //     }
-    // }
-    //
-    // // 스니펫 카드 생성 함수
-    // function createSnippetCard(snippet) {
-    //     const snippetId = snippet.snippetId;
-    //     const tags = snippetTags[snippetId] || [];
-    //
-    //     // HTML 문자열 생성
-    //     let cardHtml = '<div class="snippet-card" data-snippet-id="' + snippetId + '">';
-    //     cardHtml += '<div class="snippet-header">';
-    //     cardHtml += '<div class="snippet-snippetId">ID: ' + snippetId + '</div>';
-    //     cardHtml += '</div>';
-    //     cardHtml += '<div class="snippet-title">' + (snippet.title || snippet.memo || '제목 없음') + '</div>';
-    //     cardHtml += '<div class="snippet-meta">';
-    //
-    //     if (snippet.language) {
-    //         cardHtml += '<span class="snippet-language">' + snippet.language + '</span>';
-    //     }
-    //     if (snippet.type) {
-    //         cardHtml += '<span class="snippet-type">' + snippet.type + '</span>';
-    //     }
-    //     if (snippet.createdAt) {
-    //         cardHtml += '<span class="snippet-date">' + snippet.createdAt + '</span>';
-    //     }
-    //
-    //     cardHtml += '</div>';
-    //     cardHtml += '<div class="snippet-content">' + (snippet.content || '내용 없음') + '</div>';
-    //     cardHtml += '<div class="tag-management">';
-    //     cardHtml += '<div class="current-tags">';
-    //     cardHtml += '<div class="current-tags-label">현재 태그:</div>';
-    //     cardHtml += '<div class="tag-container" data-snippet-id="' + snippetId + '">';
-    //
-    //     if (tags.length === 0) {
-    //         cardHtml += '<span class="no-tags">태그가 없습니다</span>';
-    //     }
-    //
-    //     cardHtml += '</div>';
-    //     cardHtml += '</div>';
-    //     cardHtml += '<div class="tag-input-container">';
-    //     cardHtml += '<input type="text" class="tag-input" placeholder="태그 이름을 입력하고 엔터를 누르세요..." data-snippet-id="' + snippetId + '">';
-    //     cardHtml += '<div class="autocomplete-list"></div>';
-    //     cardHtml += '</div>';
-    //     cardHtml += '</div>';
-    //     cardHtml += '</div>';
-    //
-    //     const card = $(cardHtml);
-    //
-    //     // 태그 표시
-    //     const tagContainer = card.find('.tag-container');
-    //     if (tags.length > 0) {
-    //         tagContainer.empty();
-    //         tags.forEach(tag => {
-    //             const tagElement = $('<span class="tag-item">' + tag.name + '<span class="tag-remove">&times;</span></span>');
-    //             tagContainer.append(tagElement);
-    //         });
-    //     }
-    //
-    //     return card;
-    // }
-    //
-    // // 자동완성 표시 함수
-    // function showAutocomplete(autocompleteList, tags) {
-    //     autocompleteList.empty();
-    //
-    //     if (tags.length > 0) {
-    //         tags.forEach(tag => {
-    //             const item = $('<div class="autocomplete-item">' + tag.name + '</div>');
-    //             autocompleteList.append(item);
-    //         });
-    //         autocompleteList.show();
-    //     } else {
-    //         autocompleteList.hide();
-    //     }
-    // }
-    //
-    // // 태그 추가 함수
-    // function addTagToSnippet(input, tagName) {
-    //     const snippetId = input.data('snippet-id');
-    //     console.log(`태그 추가 시도: 스니펫 ID=${snippetId}, 태그명=${tagName}`);
-    //
-    //     if (!snippetId) {
-    //         console.error('유효하지 않은 스니펫 ID:', snippetId);
-    //         showToast('스니펫 ID를 찾을 수 없습니다.', 'error');
-    //         return;
-    //     }
-    //
-    //     if (!tagName || tagName.trim() === '') {
-    //         showToast('태그 이름을 입력하세요.', 'error');
-    //         return;
-    //     }
-    //
-    //     const currentTags = snippetTags[snippetId] || [];
-    //     console.log(`현재 태그 목록 (스니펫 ${snippetId}):`, currentTags);
-    //
-    //     const alreadyExists = currentTags.some(tag =>
-    //         tag.name.toLowerCase() === tagName.toLowerCase()
-    //     );
-    //
-    //     if (alreadyExists) {
-    //         showToast('이미 추가된 태그입니다.', 'error');
-    //         input.val('');
-    //         input.siblings('.autocomplete-list').hide();
-    //         return;
-    //     }
-    //
-    //     console.log('태그 생성 API 호출: '+ tagName);
-    //     $.ajax({
-    //         url: /*[[@{/api/tag}]]*/ '/api/tag',
-    //         method: 'POST',
-    //         contentType: 'application/json',
-    //         data: JSON.stringify({name: tagName}),
-    //         success: function (tag) {
-    //             console.log(`태그 생성 성공:`, tag);
-    //             addTagToSnippetAPI(snippetId, tag);
-    //         },
-    //         error: function (xhr, status, error) {
-    //             console.error(`태그 생성 실패:`, {
-    //                 status: xhr.status,
-    //                 statusText: xhr.statusText,
-    //                 error: error,
-    //                 response: xhr.responseText
-    //             });
-    //
-    //             if (xhr.status === 409) {
-    //                 console.log('태그가 이미 존재함. 기존 태그 사용:', xhr.responseJSON);
-    //                 const existingTag = xhr.responseJSON;
-    //                 addTagToSnippetAPI(snippetId, existingTag);
-    //             } else {
-    //                 showToast('태그 생성 중 오류가 발생했습니다.', 'error');
-    //             }
-    //         }
-    //     });
-    //
-    //     input.val('');
-    //     input.siblings('.autocomplete-list').hide();
-    // }
-    //
-    // // 스니펫에 태그 추가 API 호출 함수
-    // function addTagToSnippetAPI(snippetId, tag) {
-    //     if (!tag || !tag.tagId) {
-    //         console.error('유효하지 않은 태그:', tag);
-    //         showToast('유효하지 않은 태그입니다.', 'error');
-    //         return;
-    //     }
-    //
-    //     const apiUrl = /*[[@{/api/tag/snippet/}]]*/ '/api/tag/snippet/' + snippetId + '/tags/' + tag.tagId;
-    //     console.log(`태그 추가 API 호출: ${apiUrl}`, {snippetId, tagId: tag.tagId});
-    //
-    //     $.ajax({
-    //         url: apiUrl,
-    //         method: 'POST',
-    //         success: function (response) {
-    //             console.log(`태그 추가 성공:`, response);
-    //             showToast('태그가 추가되었습니다. 스니펫을 다시 로드합니다...');
-    //             reloadAllSnippets(snippetId);
-    //         },
-    //         error: function (xhr, status, error) {
-    //             console.error(`태그 추가 실패:`, {
-    //                 status: xhr.status,
-    //                 statusText: xhr.statusText,
-    //                 error: error,
-    //                 response: xhr.responseText,
-    //                 apiUrl: apiUrl
-    //             });
-    //             showToast('태그 추가 중 오류가 발생했습니다.', 'error');
-    //         }
-    //     });
-    // }
-    //
-    // // 태그 제거 함수
-    // function removeTagFromSnippet(snippetId, tagName, tagElement) {
-    //     const tag = (snippetTags[snippetId] || []).find(t => t.name === tagName);
-    //     if (!tag) {
-    //         showToast('태그를 찾을 수 없습니다.', 'error');
-    //         return;
-    //     }
-    //
-    //     const apiUrl = /*[[@{/api/tag/snippets/}]]*/ '/api/tag/snippets/' + snippetId + '/tags/' + tag.tagId;
-    //     console.log(`태그 제거 API 호출: ${apiUrl}`, {snippetId, tagId: tag.tagId});
-    //
-    //     $.ajax({
-    //         url: apiUrl,
-    //         method: 'DELETE',
-    //         success: function () {
-    //             showToast('태그가 제거되었습니다. 스니펫을 다시 로드합니다...');
-    //             reloadAllSnippets(snippetId);
-    //         },
-    //         error: function (xhr, status, error) {
-    //             console.error(`태그 제거 실패:`, {
-    //                 status: xhr.status,
-    //                 error: error
-    //             });
-    //             showToast('태그 제거 중 오류가 발생했습니다.', 'error');
-    //         }
-    //     });
-    // }
-    //
-    // // 스니펫 태그 UI 업데이트 함수
-    // function updateSnippetTagsUI(snippetId) {
-    //     const card = $(`.snippet-card[data-snippet-id="${snippetId}"]`);
-    //     const tagContainer = card.find('.tag-container');
-    //     const tags = snippetTags[snippetId] || [];
-    //
-    //     tagContainer.empty();
-    //
-    //     if (tags.length === 0) {
-    //         tagContainer.html('<span class="no-tags">태그가 없습니다</span>');
-    //     } else {
-    //         tags.forEach(tag => {
-    //             const tagElement = $('<span class="tag-item">' + tag.name + '<span class="tag-remove">&times;</span></span>');
-    //             tagContainer.append(tagElement);
-    //         });
-    //     }
-    // }
-    //
-    // // 스니펫 다시 로드 함수
-    // function reloadAllSnippets(focusSnippetId) {
-    //     console.log('===== 모든 스니펫 다시 로드 시작 =====');
-    //     console.log('로드 후 포커스할 스니펫 ID:', focusSnippetId);
-    //
-    //     $('#snippetsContainer').html('<div class="loading">스니펫을 다시 불러오는 중...</div>');
-    //
-    //     $.ajax({
-    //         url: /*[[@{/api/snippet}]]*/ '/api/snippet',
-    //         method: 'GET',
-    //         success: function(snippets) {
-    //             console.log('스니펫 API 호출 성공, 스니펫 수:', snippets.length);
-    //             allSnippets = snippets;
-    //             snippetTags = {};
-    //             loadSnippetTags(focusSnippetId);
-    //         },
-    //         error: function(xhr, status, error) {
-    //             console.error('스니펫 다시 로드 실패:', error);
-    //             showToast('스니펫을 다시 로드하는데 실패했습니다.', 'error');
-    //             displaySnippets(allSnippets, focusSnippetId);
-    //         }
-    //     });
-    // }
-    //
-    // // 스니펫 필터링 함수
-    // function filterSnippets(keyword) {
-    //     const filteredSnippets = allSnippets.filter(snippet => {
-    //         const searchableText = [
-    //             snippet.title || '',
-    //             snippet.content || '',
-    //             snippet.memo || '',
-    //             snippet.language || '',
-    //             snippet.type || ''
-    //         ].join(' ').toLowerCase();
-    //
-    //         // 태그도 검색에 포함
-    //         const tags = snippetTags[snippet.snippetId] || [];
-    //         const tagNames = tags.map(tag => tag.name).join(' ').toLowerCase();
-    //
-    //         return searchableText.includes(keyword) || tagNames.includes(keyword);
-    //     });
-    //
-    //     displaySnippets(filteredSnippets);
-    // }
-    //
-    // // 토스트 메시지 표시 함수
-    // function showToast(message, type) {
-    //     type = type || 'success';
-    //     const toast = $('#toast');
-    //     toast.removeClass('error').text(message);
-    //
-    //     if (type === 'error') {
-    //         toast.addClass('error');
-    //     }
-    //
-    //     toast.fadeIn(300);
-    //     setTimeout(function () {
-    //         toast.fadeOut(300);
-    //     }, 3000);
-    // }
-    //
-    // // 에러 메시지 표시 함수
-    // function showError(message) {
-    //     $('#errorMessage').text(message).show();
-    // }
-    //
-    // // 외부 클릭시 자동완성 닫기
-    // $(document).on('click', function (e) {
-    //     if (!$(e.target).closest('.tag-input-container').length) {
-    //         $('.autocomplete-list').hide();
-    //     }
-    // });
-// });
+         if (keyword.length > 0) {
+             const filteredTags = allTags.filter(tag =>
+                 tag.name.toLowerCase().includes(keyword.toLowerCase())
+             );
+             showAutocomplete(autocompleteList, filteredTags);
+         } else {
+             autocompleteList.hide();
+         }
+     });
+
+     // 태그 입력 키보드 이벤트
+     $(document).on('keydown', '.tag-input', function (e) {
+         const input = $(this);
+         const autocompleteList = input.siblings('.autocomplete-list');
+         const items = autocompleteList.find('.autocomplete-item');
+         const selectedItem = items.filter('.selected');
+
+         if (e.key === 'ArrowDown') {
+             e.preventDefault();
+             if (selectedItem.length === 0) {
+                 items.first().addClass('selected');
+             } else {
+                 selectedItem.removeClass('selected');
+                 const next = selectedItem.next();
+                 if (next.length > 0) {
+                     next.addClass('selected');
+                 } else {
+                     items.first().addClass('selected');
+                 }
+             }
+         } else if (e.key === 'ArrowUp') {
+             e.preventDefault();
+             if (selectedItem.length === 0) {
+                 items.last().addClass('selected');
+             } else {
+                 selectedItem.removeClass('selected');
+                 const prev = selectedItem.prev();
+                 if (prev.length > 0) {
+                     prev.addClass('selected');
+                 } else {
+                     items.last().addClass('selected');
+                 }
+             }
+         } else if (e.key === 'Enter') {
+             e.preventDefault();
+             if (selectedItem.length > 0) {
+                 const tagName = selectedItem.text();
+                 addTagToSnippet(input, tagName);
+             } else {
+                 const tagName = input.val().trim();
+                 if (tagName) {
+                     addTagToSnippet(input, tagName);
+                 }
+             }
+         } else if (e.key === 'Escape') {
+             autocompleteList.hide();
+         }
+     });
+
+     // 자동완성 클릭
+     $(document).on('click', '.autocomplete-item', function () {
+         const tagName = $(this).text();
+         const input = $(this).closest('.tag-input-container').find('.tag-input');
+         addTagToSnippet(input, tagName);
+     });
+
+     // 태그 제거
+     $(document).on('click', '.tag-remove', function (e) {
+         e.preventDefault();
+         const tagElement = $(this).closest('.tag-item');
+         const tagName = tagElement.text().replace('×', '').trim();
+         const snippetId = $(this).closest('.snippet-card').data('snippet-id');
+
+         removeTagFromSnippet(snippetId, tagName, tagElement);
+     });
+
+     // 함수들
+     function loadInitialData() {
+         // 모든 태그 로드
+         $.ajax({
+             url: /*[[@{/api/tag}]]*/ '/api/tag',
+             method: 'GET',
+             success: function (tags) {
+                 console.log('모든 태그 로드 성공:', tags);
+                 allTags = tags || [];
+             },
+             error: function (xhr) {
+                 console.error('태그 목록 로드 실패:', xhr.status);
+                 allTags = [];
+                 showError('태그 목록을 불러오는데 실패했습니다.');
+             },
+             complete: function () {
+                 // 태그 로드 후 스니펫 로드
+                 loadSnippets();
+             }
+         });
+     }
+
+     function loadSnippets() {
+         console.log('===== 스니펫 로드 시작 =====');
+
+         $.ajax({
+             url: /*[[@{/api/snippet}]]*/ '/api/snippet',
+             method: 'GET',
+             success: function(snippets) {
+                 console.log('스니펫 API 호출 성공');
+
+                 // 응답 데이터 구조 확인
+                 console.log('응답 데이터 타입:', typeof snippets);
+                 console.log('응답이 배열인가?', Array.isArray(snippets));
+
+                 // 응답에서 배열 데이터 추출
+                 if (!Array.isArray(snippets)) {
+                     console.log('응답이 배열이 아님. 변환 시도...');
+                     if (snippets && typeof snippets === 'object') {
+                         if (snippets.content && Array.isArray(snippets.content)) {
+                             snippets = snippets.content;
+                         }
+                     }
+                 }
+
+                 // 데이터 샘플 확인
+                 if (Array.isArray(snippets) && snippets.length > 0) {
+                     console.log('첫 번째 스니펫 구조:', snippets[0]);
+                 }
+
+                 // 필드 정규화 및 유효한 스니펫 필터링
+                 allSnippets = [];
+                 if (Array.isArray(snippets)) {
+                     // 간단히 원본 데이터를 사용
+                     allSnippets = snippets.filter(snippet => snippet !== null && snippet !== undefined);
+
+                     // 디버깅을 위해 첫 몇 개 스니펫의 ID 출력
+                     allSnippets.slice(0, 3).forEach((snippet, index) => {
+                         console.log(`스니펫 ${index}의 ID(snippetId): ${snippet.snippetId}`);
+                     });
+                 }
+
+                 console.log('처리된 스니펫 수:', allSnippets.length);
+
+                 // 필터링 후에도 스니펫이 없으면 더미 데이터 사용
+                 if (allSnippets.length === 0) {
+                     console.log('스니펫이 없어 더미 데이터를 사용합니다.');
+                     allSnippets = getDummySnippets();
+                 }
+
+                 // 태그 로드 시작
+                 loadSnippetTags();
+             },
+             error: function(xhr, status, error) {
+                 console.error('스니펫 로드 실패:', error);
+                 console.log('에러 응답:', xhr.responseText);
+
+                 console.log('더미 데이터 사용');
+                 allSnippets = getDummySnippets();
+
+                 // 태그 로드 시작
+                 loadSnippetTags();
+             }
+         });
+     }
+
+     // 태그 로드 함수
+     function loadSnippetTags(focusSnippetId) {
+         console.log("모든 스니펫 태그 로드 시작");
+         if (!allSnippets || allSnippets.length === 0) {
+             console.log('로드할 스니펫이 없습니다.');
+             displaySnippets([], focusSnippetId);
+             return;
+         }
+
+         console.log('스니펫 태그 로드 시작 - 총 스니펫 수:', allSnippets.length);
+
+         let loaded = 0;
+         const totalSnippets = allSnippets.length;
+
+         // 모든 스니펫의 태그 초기화
+         allSnippets.forEach(snippet => {
+             const snippetId = snippet.snippetId;
+             console.log(`스니펫 태그 초기화, ID: ${snippetId}`);
+             snippetTags[snippetId] = [];
+         });
+
+         // 태그 로드
+         allSnippets.forEach((snippet, index) => {
+             const snippetId = snippet.snippetId;
+             console.log(`스니펫 ${index}의 태그 로드, ID: ${snippetId}`);
+
+             if (!snippetId) {
+                 console.error(`스니펫 ${index}에 유효한 ID가 없습니다:`, snippet);
+                 loaded++;
+                 checkAllLoaded();
+                 return;
+             }
+
+             const apiUrl = /*[[@{/api/tag/snippets/}]]*/ '/api/tag/snippets/' + snippetId;
+             console.log('태그 API URL:', apiUrl);
+
+             $.ajax({
+                 url: apiUrl,
+                 method: 'GET',
+                 success: function(tags) {
+                     console.log('스니펫 ID - '+snippetId+'의 태그 로드 성공:', tags);
+                     if (Array.isArray(tags)) {
+                         snippetTags[snippetId] = tags;
+                     } else {
+                         console.warn(`스니펫 ID ${snippetId}의 태그 응답이 배열이 아님:`, tags);
+                         snippetTags[snippetId] = [];
+                     }
+                 },
+                 error: function(xhr, status, error) {
+                     console.error(`스니펫 ID ${snippetId}의 태그 로드 실패:`, {
+                         status: xhr.status,
+                         error: error
+                     });
+                     snippetTags[snippetId] = [];
+                 },
+                 complete: function() {
+                     loaded++;
+                     console.log(`태그 로드 진행 상황: ${loaded}/${totalSnippets}`);
+                     checkAllLoaded();
+                 }
+             });
+         });
+
+         // 모든 태그 로드 완료 확인
+         function checkAllLoaded() {
+             if (loaded >= totalSnippets) {
+                 console.log('모든 스니펫의 태그 로드 완료');
+                 displaySnippets(allSnippets, focusSnippetId);
+             }
+         }
+
+         // 안전장치
+         setTimeout(function() {
+             if (loaded < totalSnippets) {
+                 console.warn(`태그 로드 타임아웃: ${loaded}/${totalSnippets} 완료`);
+                 displaySnippets(allSnippets, focusSnippetId);
+             }
+         }, 5000);
+     }
+
+     // 더미 스니펫 데이터
+     function getDummySnippets() {
+         const dummySnippets = [
+             {
+                 snippetId: 1,
+                 title: 'JavaScript 배열 맵',
+                 content: 'const numbers = [1, 2, 3, 4, 5];\nconst doubled = numbers.map(num => num * 2);',
+                 language: 'javascript',
+                 type: 'code',
+                 createdAt: '2023-02-01',
+                 memo: 'JavaScript 배열 맵 함수 예제'
+             },
+             {
+                 snippetId: 2,
+                 title: 'React Hook 예제',
+                 content: 'import React, { useState } from "react";\n\nfunction Counter() {\n  const [count, setCount] = useState(0);\n  return <div>{count}</div>;\n}',
+                 language: 'jsx',
+                 type: 'code',
+                 createdAt: '2023-02-03',
+                 memo: 'React useState 훅 사용법'
+             },
+             {
+                 snippetId: 3,
+                 title: 'Date 포맷팅',
+                 content: 'function formatDate(date) {\n  return date.toISOString().split("T")[0];\n}',
+                 language: 'javascript',
+                 type: 'code',
+                 createdAt: '2023-02-05',
+                 memo: '날짜 포맷팅 유틸리티 함수'
+             }
+         ];
+
+         console.log('더미 스니펫 생성:', dummySnippets.length);
+         return dummySnippets;
+     }
+
+     // 스니펫 표시 함수
+     function displaySnippets(snippets, focusSnippetId) {
+         const container = $('#snippetsContainer');
+         container.empty();
+
+         if (snippets.length === 0) {
+             container.html('<div class="loading">표시할 스니펫이 없습니다.</div>');
+             return;
+         }
+
+         snippets.forEach(snippet => {
+             const snippetCard = createSnippetCard(snippet);
+             container.append(snippetCard);
+         });
+
+         // 포커스 설정 (지정된 스니펫 ID가 있는 경우)
+         if (focusSnippetId) {
+             console.log(`지정된 스니펫 ID ${focusSnippetId}로 포커스 이동 시도`);
+
+             // 약간의 지연을 두고 포커스 설정 (DOM이 완전히 렌더링된 후)
+             setTimeout(function() {
+                 const card = $(`.snippet-card[data-snippet-id="${focusSnippetId}"]`);
+                 if (card.length > 0) {
+                     console.log(`스니펫 ID ${focusSnippetId}의 카드를 찾음`);
+
+                     // 입력 필드에 포커스
+                     const inputField = card.find('.tag-input');
+                     if (inputField.length > 0) {
+                         // 카드가 화면에 보이도록 스크롤
+                         $('html, body').animate({
+                             scrollTop: card.offset().top - 100 // 상단에서 100px 위치에 스크롤
+                         }, 300);
+
+                         // 포커스 설정
+                         inputField.focus();
+                         console.log(`스니펫 ID ${focusSnippetId}의 태그 입력 필드에 포커스 설정 완료`);
+                     } else {
+                         console.warn(`스니펫 ID ${focusSnippetId}의 태그 입력 필드를 찾을 수 없음`);
+                     }
+                 } else {
+                     console.warn(`스니펫 ID ${focusSnippetId}의 카드를 찾을 수 없음`);
+                 }
+             }, 300);
+         }
+     }
+
+     // 스니펫 카드 생성 함수
+     function createSnippetCard(snippet) {
+         const snippetId = snippet.snippetId;
+         const tags = snippetTags[snippetId] || [];
+
+         // HTML 문자열 생성
+         let cardHtml = '<div class="snippet-card" data-snippet-id="' + snippetId + '">';
+         cardHtml += '<div class="snippet-header">';
+         cardHtml += '<div class="snippet-snippetId">ID: ' + snippetId + '</div>';
+         cardHtml += '</div>';
+         cardHtml += '<div class="snippet-title">' + (snippet.title || snippet.memo || '제목 없음') + '</div>';
+         cardHtml += '<div class="snippet-meta">';
+
+         if (snippet.language) {
+             cardHtml += '<span class="snippet-language">' + snippet.language + '</span>';
+         }
+         if (snippet.type) {
+             cardHtml += '<span class="snippet-type">' + snippet.type + '</span>';
+         }
+         if (snippet.createdAt) {
+             cardHtml += '<span class="snippet-date">' + snippet.createdAt + '</span>';
+         }
+
+         cardHtml += '</div>';
+         cardHtml += '<div class="snippet-content">' + (snippet.content || '내용 없음') + '</div>';
+         cardHtml += '<div class="tag-management">';
+         cardHtml += '<div class="current-tags">';
+         cardHtml += '<div class="current-tags-label">현재 태그:</div>';
+         cardHtml += '<div class="tag-container" data-snippet-id="' + snippetId + '">';
+
+         if (tags.length === 0) {
+             cardHtml += '<span class="no-tags">태그가 없습니다</span>';
+         }
+
+         cardHtml += '</div>';
+         cardHtml += '</div>';
+         cardHtml += '<div class="tag-input-container">';
+         cardHtml += '<input type="text" class="tag-input" placeholder="태그 이름을 입력하고 엔터를 누르세요..." data-snippet-id="' + snippetId + '">';
+         cardHtml += '<div class="autocomplete-list"></div>';
+         cardHtml += '</div>';
+         cardHtml += '</div>';
+         cardHtml += '</div>';
+
+         const card = $(cardHtml);
+
+         // 태그 표시
+         const tagContainer = card.find('.tag-container');
+         if (tags.length > 0) {
+             tagContainer.empty();
+             tags.forEach(tag => {
+                 const tagElement = $('<span class="tag-item">' + tag.name + '<span class="tag-remove">&times;</span></span>');
+                 tagContainer.append(tagElement);
+             });
+         }
+
+         return card;
+     }
+
+     // 자동완성 표시 함수
+     function showAutocomplete(autocompleteList, tags) {
+         autocompleteList.empty();
+
+         if (tags.length > 0) {
+             tags.forEach(tag => {
+                 const item = $('<div class="autocomplete-item">' + tag.name + '</div>');
+                 autocompleteList.append(item);
+             });
+             autocompleteList.show();
+         } else {
+             autocompleteList.hide();
+         }
+     }
+
+     // 태그 추가 함수
+     function addTagToSnippet(input, tagName) {
+         const snippetId = input.data('snippet-id');
+         console.log(`태그 추가 시도: 스니펫 ID=${snippetId}, 태그명=${tagName}`);
+
+         if (!snippetId) {
+             console.error('유효하지 않은 스니펫 ID:', snippetId);
+             showToast('스니펫 ID를 찾을 수 없습니다.', 'error');
+             return;
+         }
+
+         if (!tagName || tagName.trim() === '') {
+             showToast('태그 이름을 입력하세요.', 'error');
+             return;
+         }
+
+         const currentTags = snippetTags[snippetId] || [];
+         console.log(`현재 태그 목록 (스니펫 ${snippetId}):`, currentTags);
+
+         const alreadyExists = currentTags.some(tag =>
+             tag.name.toLowerCase() === tagName.toLowerCase()
+         );
+
+         if (alreadyExists) {
+             showToast('이미 추가된 태그입니다.', 'error');
+             input.val('');
+             input.siblings('.autocomplete-list').hide();
+             return;
+         }
+
+         console.log('태그 생성 API 호출: '+ tagName);
+         $.ajax({
+             url: /*[[@{/api/tag}]]*/ '/api/tag',
+             method: 'POST',
+             contentType: 'application/json',
+             data: JSON.stringify({name: tagName}),
+             success: function (tag) {
+                 console.log(`태그 생성 성공:`, tag);
+                 addTagToSnippetAPI(snippetId, tag);
+             },
+             error: function (xhr, status, error) {
+                 console.error(`태그 생성 실패:`, {
+                     status: xhr.status,
+                     statusText: xhr.statusText,
+                     error: error,
+                     response: xhr.responseText
+                 });
+
+                 if (xhr.status === 409) {
+                     console.log('태그가 이미 존재함. 기존 태그 사용:', xhr.responseJSON);
+                     const existingTag = xhr.responseJSON;
+                     addTagToSnippetAPI(snippetId, existingTag);
+                 } else {
+                     showToast('태그 생성 중 오류가 발생했습니다.', 'error');
+                 }
+             }
+         });
+
+         input.val('');
+         input.siblings('.autocomplete-list').hide();
+     }
+
+     // 스니펫에 태그 추가 API 호출 함수
+     function addTagToSnippetAPI(snippetId, tag) {
+         if (!tag || !tag.tagId) {
+             console.error('유효하지 않은 태그:', tag);
+             showToast('유효하지 않은 태그입니다.', 'error');
+             return;
+         }
+
+         const apiUrl = /*[[@{/api/tag/snippet/}]]*/ '/api/tag/snippet/' + snippetId + '/tags/' + tag.tagId;
+         console.log(`태그 추가 API 호출: ${apiUrl}`, {snippetId, tagId: tag.tagId});
+
+         $.ajax({
+             url: apiUrl,
+             method: 'POST',
+             success: function (response) {
+                 console.log(`태그 추가 성공:`, response);
+                 showToast('태그가 추가되었습니다. 스니펫을 다시 로드합니다...');
+                 reloadAllSnippets(snippetId);
+             },
+             error: function (xhr, status, error) {
+                 console.error(`태그 추가 실패:`, {
+                     status: xhr.status,
+                     statusText: xhr.statusText,
+                     error: error,
+                     response: xhr.responseText,
+                     apiUrl: apiUrl
+                 });
+                 showToast('태그 추가 중 오류가 발생했습니다.', 'error');
+             }
+         });
+     }
+
+     // 태그 제거 함수
+     function removeTagFromSnippet(snippetId, tagName, tagElement) {
+         const tag = (snippetTags[snippetId] || []).find(t => t.name === tagName);
+         if (!tag) {
+             showToast('태그를 찾을 수 없습니다.', 'error');
+             return;
+         }
+
+         const apiUrl = /*[[@{/api/tag/snippets/}]]*/ '/api/tag/snippets/' + snippetId + '/tags/' + tag.tagId;
+         console.log(`태그 제거 API 호출: ${apiUrl}`, {snippetId, tagId: tag.tagId});
+
+         $.ajax({
+             url: apiUrl,
+             method: 'DELETE',
+             success: function () {
+                 showToast('태그가 제거되었습니다. 스니펫을 다시 로드합니다...');
+                 reloadAllSnippets(snippetId);
+             },
+             error: function (xhr, status, error) {
+                 console.error(`태그 제거 실패:`, {
+                     status: xhr.status,
+                     error: error
+                 });
+                 showToast('태그 제거 중 오류가 발생했습니다.', 'error');
+             }
+         });
+     }
+
+     // 스니펫 태그 UI 업데이트 함수
+     function updateSnippetTagsUI(snippetId) {
+         const card = $(`.snippet-card[data-snippet-id="${snippetId}"]`);
+         const tagContainer = card.find('.tag-container');
+         const tags = snippetTags[snippetId] || [];
+
+         tagContainer.empty();
+
+         if (tags.length === 0) {
+             tagContainer.html('<span class="no-tags">태그가 없습니다</span>');
+         } else {
+             tags.forEach(tag => {
+                 const tagElement = $('<span class="tag-item">' + tag.name + '<span class="tag-remove">&times;</span></span>');
+                 tagContainer.append(tagElement);
+             });
+         }
+     }
+
+     // 스니펫 다시 로드 함수
+     function reloadAllSnippets(focusSnippetId) {
+         console.log('===== 모든 스니펫 다시 로드 시작 =====');
+         console.log('로드 후 포커스할 스니펫 ID:', focusSnippetId);
+
+         $('#snippetsContainer').html('<div class="loading">스니펫을 다시 불러오는 중...</div>');
+
+         $.ajax({
+             url: /*[[@{/api/snippet}]]*/ '/api/snippet',
+             method: 'GET',
+             success: function(snippets) {
+                 console.log('스니펫 API 호출 성공, 스니펫 수:', snippets.length);
+                 allSnippets = snippets;
+                 snippetTags = {};
+                 loadSnippetTags(focusSnippetId);
+             },
+             error: function(xhr, status, error) {
+                 console.error('스니펫 다시 로드 실패:', error);
+                 showToast('스니펫을 다시 로드하는데 실패했습니다.', 'error');
+                 displaySnippets(allSnippets, focusSnippetId);
+             }
+         });
+     }
+
+     // 스니펫 필터링 함수
+     function filterSnippets(keyword) {
+         const filteredSnippets = allSnippets.filter(snippet => {
+             const searchableText = [
+                 snippet.title || '',
+                 snippet.content || '',
+                 snippet.memo || '',
+                 snippet.language || '',
+                 snippet.type || ''
+             ].join(' ').toLowerCase();
+
+             // 태그도 검색에 포함
+             const tags = snippetTags[snippet.snippetId] || [];
+             const tagNames = tags.map(tag => tag.name).join(' ').toLowerCase();
+
+             return searchableText.includes(keyword) || tagNames.includes(keyword);
+         });
+
+         displaySnippets(filteredSnippets);
+     }
+
+     // 토스트 메시지 표시 함수
+     function showToast(message, type) {
+         type = type || 'success';
+         const toast = $('#toast');
+         toast.removeClass('error').text(message);
+
+         if (type === 'error') {
+             toast.addClass('error');
+         }
+
+         toast.fadeIn(300);
+         setTimeout(function () {
+             toast.fadeOut(300);
+         }, 3000);
+     }
+
+     // 에러 메시지 표시 함수
+     function showError(message) {
+         $('#errorMessage').text(message).show();
+     }
+
+     // 외부 클릭시 자동완성 닫기
+     $(document).on('click', function (e) {
+         if (!$(e.target).closest('.tag-input-container').length) {
+             $('.autocomplete-list').hide();
+         }
+     });
+ });

--- a/src/main/resources/templates/tag/auth-status.html
+++ b/src/main/resources/templates/tag/auth-status.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>인증 상태 확인</title>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .status-box {
+            background: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 15px;
+            margin: 10px 0;
+        }
+        .authenticated {
+            background: #d4edda;
+            border-color: #c3e6cb;
+            color: #155724;
+        }
+        .not-authenticated {
+            background: #f8d7da;
+            border-color: #f5c6cb;
+            color: #721c24;
+        }
+        .button {
+            background: #007bff;
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 4px;
+            cursor: pointer;
+            margin: 5px;
+            text-decoration: none;
+            display: inline-block;
+        }
+        .button:hover {
+            background: #0056b3;
+        }
+        .warning {
+            background: #fff3cd;
+            border: 1px solid #ffeeba;
+            color: #856404;
+            padding: 10px;
+            border-radius: 4px;
+            margin: 10px 0;
+        }
+        pre {
+            background: #f1f3f5;
+            padding: 10px;
+            border-radius: 4px;
+            overflow-x: auto;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>🔐 인증 상태 확인</h1>
+
+    <div class="warning">
+        ⚠️ 이 페이지는 개발 환경에서만 사용하세요!
+    </div>
+
+    <h2>현재 인증 상태</h2>
+    <div id="authStatus" class="status-box">
+        확인 중...
+    </div>
+
+    <h2>테스트 로그인</h2>
+    <p>아래 버튼을 클릭하면 해당 사용자로 임시 로그인됩니다:</p>
+    <a href="/test/login-as/1" class="button">User ID 1로 로그인</a>
+    <a href="/test/login-as/2" class="button">User ID 2로 로그인</a>
+    <a href="/test/login-as/3" class="button">User ID 3로 로그인</a>
+
+    <h2>API 테스트</h2>
+    <button class="button" onclick="checkAuth()">인증 확인 (/api/tag/auth-check)</button>
+    <button class="button" onclick="getMyTags()">내 태그 조회 (/api/tag/my-tags)</button>
+
+    <div id="apiResult" style="margin-top: 10px;">
+        <pre id="resultContent"></pre>
+    </div>
+
+    <h2>태그 관리 페이지로 이동</h2>
+    <a href="/tags/manager" class="button">태그 관리자</a>
+    <a href="/tags/snippet-tag" class="button">스니펫 태그 관리</a>
+</div>
+
+<script>
+    // 페이지 로드 시 인증 상태 확인
+    $(document).ready(function() {
+        checkAuthStatus();
+    });
+
+    function checkAuthStatus() {
+        $.get('/api/tag/auth-check', function(data) {
+            if (data.authenticated) {
+                $('#authStatus').removeClass('not-authenticated').addClass('authenticated');
+                $('#authStatus').html(`
+                    <strong>✅ 인증됨</strong><br>
+                    사용자 ID: ${data.userId}<br>
+                    사용자명: ${data.username}<br>
+                    권한: ${JSON.stringify(data.authorities)}
+                `);
+            } else {
+                $('#authStatus').removeClass('authenticated').addClass('not-authenticated');
+                $('#authStatus').html('<strong>❌ 인증되지 않음</strong><br>로그인이 필요합니다.');
+            }
+        }).fail(function() {
+            $('#authStatus').removeClass('authenticated').addClass('not-authenticated');
+            $('#authStatus').html('<strong>❌ 인증 확인 실패</strong><br>401 Unauthorized');
+        });
+    }
+
+    function checkAuth() {
+        $.get('/api/tag/auth-check', function(data) {
+            $('#resultContent').text(JSON.stringify(data, null, 2));
+        }).fail(function(xhr) {
+            $('#resultContent').text('Error: ' + xhr.status + ' - ' + xhr.statusText);
+        });
+    }
+
+    function getMyTags() {
+        $.get('/api/tag/my-tags', function(data) {
+            $('#resultContent').text(JSON.stringify(data, null, 2));
+        }).fail(function(xhr) {
+            $('#resultContent').text('Error: ' + xhr.status + ' - ' + xhr.statusText);
+        });
+    }
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/tag/snippet-tags.html
+++ b/src/main/resources/templates/tag/snippet-tags.html
@@ -1,32 +1,545 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>스니펫 태그 관리</title>
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <link th:href="@{/tag/css/snippet-tags.css}" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <style>
+        body {
+            background-color: #f8f9fa;
+        }
+
+        .main-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+
+        .snippet-card {
+            background: white;
+            border-radius: 10px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+            transition: all 0.3s ease;
+            margin-bottom: 20px;
+            border: none;
+        }
+
+        .snippet-card:hover {
+            transform: translateY(-3px);
+            box-shadow: 0 5px 20px rgba(0,0,0,0.15);
+        }
+
+        .snippet-header {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 20px;
+            border-radius: 10px 10px 0 0;
+        }
+
+        .snippet-title {
+            font-size: 1.2rem;
+            font-weight: 600;
+            margin: 0;
+        }
+
+        .snippet-type {
+            display: inline-block;
+            background: rgba(255,255,255,0.2);
+            padding: 3px 10px;
+            border-radius: 15px;
+            font-size: 0.8rem;
+            margin-top: 5px;
+        }
+
+        .tag-input-section {
+            padding: 20px;
+            background: #f1f3f5;
+            border-radius: 0 0 10px 10px;
+        }
+
+        .tag-input-wrapper {
+            position: relative;
+        }
+
+        .tag-input {
+            width: 100%;
+            padding: 12px 20px;
+            border: 2px solid #e9ecef;
+            border-radius: 25px;
+            font-size: 0.95rem;
+            transition: all 0.3s ease;
+        }
+
+        .tag-input:focus {
+            outline: none;
+            border-color: #667eea;
+            box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        }
+
+        .tag-suggestions {
+            position: absolute;
+            top: 100%;
+            left: 0;
+            right: 0;
+            background: white;
+            border: 1px solid #e9ecef;
+            border-radius: 10px;
+            margin-top: 5px;
+            max-height: 200px;
+            overflow-y: auto;
+            display: none;
+            z-index: 1000;
+            box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+        }
+
+        .tag-suggestions.show {
+            display: block;
+        }
+
+        .suggestion-item {
+            padding: 10px 20px;
+            cursor: pointer;
+            transition: background-color 0.2s;
+        }
+
+        .suggestion-item:hover {
+            background-color: #f8f9fa;
+        }
+
+        .suggestion-item.selected {
+            background-color: #e9ecef;
+        }
+
+        .suggestion-new {
+            color: #667eea;
+            font-weight: 500;
+        }
+
+        .current-tags {
+            margin-top: 15px;
+            padding: 15px;
+            background: white;
+            border-radius: 10px;
+            min-height: 60px;
+        }
+
+        .tag-badge {
+            display: inline-block;
+            background: #667eea;
+            color: white;
+            padding: 6px 15px;
+            border-radius: 20px;
+            font-size: 0.85rem;
+            margin: 3px;
+            position: relative;
+            animation: tagFadeIn 0.3s ease;
+        }
+
+        @keyframes tagFadeIn {
+            from {
+                opacity: 0;
+                transform: scale(0.8);
+            }
+            to {
+                opacity: 1;
+                transform: scale(1);
+            }
+        }
+
+        .tag-badge .remove-tag {
+            margin-left: 8px;
+            cursor: pointer;
+            font-weight: bold;
+            transition: color 0.2s;
+        }
+
+        .tag-badge .remove-tag:hover {
+            color: #ffd4d4;
+        }
+
+        .empty-tags {
+            color: #868e96;
+            font-size: 0.9rem;
+            text-align: center;
+            padding: 10px;
+        }
+
+        .add-tag-hint {
+            font-size: 0.85rem;
+            color: #868e96;
+            margin-top: 8px;
+        }
+
+        .loading-spinner {
+            display: inline-block;
+            width: 16px;
+            height: 16px;
+            border: 2px solid #f3f3f3;
+            border-top: 2px solid #667eea;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+            margin-left: 10px;
+        }
+
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+
+        .error-message {
+            color: #dc3545;
+            font-size: 0.85rem;
+            margin-top: 5px;
+        }
+
+        .success-message {
+            color: #28a745;
+            font-size: 0.85rem;
+            margin-top: 5px;
+        }
+    </style>
 </head>
 <body>
-<div class="container">
-    <h1>📝 스니펫 태그 관리</h1>
-
-    <div class="search-bar">
-        <input type="text"
-               id="snippetSearch"
-               class="search-input"
-               placeholder="스니펫 검색 (제목, 내용, 태그...)">
+<div class="main-container">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1><i class="fas fa-tags me-2"></i>스니펫 태그 관리</h1>
+        <a href="/tags/manager" class="btn btn-outline-primary">
+            <i class="fas fa-cog me-2"></i>태그 관리
+        </a>
     </div>
 
-    <div id="errorMessage" class="error" style="display: none;"></div>
+    <!-- 로그인 필요 메시지 -->
+    <div th:if="${userId == null}" class="alert alert-warning">
+        <i class="fas fa-exclamation-triangle me-2"></i>
+        로그인이 필요한 서비스입니다. <a href="/login" class="alert-link">로그인하기</a>
+    </div>
 
-    <div id="snippetsContainer" class="snippets-grid">
-        <div class="loading">스니펫을 불러오는 중...</div>
+    <!-- 스니펫 목록 -->
+    <div th:if="${userId != null}" class="row">
+        <div th:each="snippet : ${snippetList}" class="col-lg-6">
+            <div class="snippet-card">
+                <div class="snippet-header">
+                    <h3 class="snippet-title">
+                        <i class="fas fa-code me-2"></i>
+                        <span th:text="${snippet.memo != null ? snippet.memo : 'Snippet #' + snippet.snippetId}">스니펫 제목</span>
+                    </h3>
+                    <span class="snippet-type" th:text="${snippet.type}">TYPE</span>
+                </div>
+
+                <div class="tag-input-section">
+                    <!-- 태그 입력 영역 -->
+                    <div class="tag-input-wrapper">
+                        <input type="text"
+                               class="tag-input"
+                               th:id="'tagInput-' + ${snippet.snippetId}"
+                               th:data-snippet-id="${snippet.snippetId}"
+                               placeholder="태그를 입력하고 Enter를 누르세요"
+                               autocomplete="off">
+                        <div class="tag-suggestions" th:id="'suggestions-' + ${snippet.snippetId}"></div>
+                    </div>
+
+                    <div class="add-tag-hint">
+                        <i class="fas fa-info-circle me-1"></i>
+                        태그를 입력하면 자동완성이 표시됩니다. Enter 또는 클릭으로 선택하세요.
+                    </div>
+
+                    <!-- 메시지 영역 -->
+                    <div th:id="'message-' + ${snippet.snippetId}" class="mt-2"></div>
+
+                    <!-- 현재 태그 목록 -->
+                    <div class="current-tags">
+                        <div class="mb-2">
+                            <strong>현재 태그:</strong>
+                            <span class="loading-spinner" th:id="'loading-' + ${snippet.snippetId}" style="display: none;"></span>
+                        </div>
+                        <div th:id="'tags-' + ${snippet.snippetId}" class="tags-container">
+                            <div class="empty-tags">태그를 불러오는 중...</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- 스니펫이 없는 경우 -->
+        <div th:if="${#lists.isEmpty(snippetList)}" class="col-12">
+            <div class="alert alert-info text-center">
+                <i class="fas fa-inbox fa-3x mb-3"></i>
+                <h4>아직 스니펫이 없습니다</h4>
+                <p>스니펫을 생성한 후 태그를 추가해보세요!</p>
+                <a href="/snippets/create" class="btn btn-primary">
+                    <i class="fas fa-plus me-2"></i>첫 스니펫 만들기
+                </a>
+            </div>
+        </div>
     </div>
 </div>
 
-<!-- 플로팅 알림 -->
-<div id="toast" class="toast"></div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+<script th:inline="javascript">
+    const userId = /*[[${userId}]]*/ null;
+    const snippetList = /*[[${snippetList}]]*/ [];
+    let allUserTags = [];
+    let selectedSuggestionIndex = -1;
 
-<script th:src="@{/tag/js/snippet-tags.js}"></script>
+    // 페이지 로드 시 초기화
+    $(document).ready(function() {
+        if (userId) {
+            loadAllUserTags();
+            initializeTagInputs();
+            loadAllSnippetTags();
+        }
+    });
+
+    // 사용자의 모든 태그 로드
+    function loadAllUserTags() {
+        $.get('/api/tag/my-tags')
+            .done(function(tags) {
+                allUserTags = tags;
+                console.log('사용자 태그 로드 완료:', allUserTags.length);
+            })
+            .fail(function(xhr) {
+                console.error('태그 로드 실패:', xhr.responseText);
+            });
+    }
+
+    // 모든 스니펫의 태그 로드
+    function loadAllSnippetTags() {
+        snippetList.forEach(snippet => {
+            loadSnippetTags(snippet.snippetId);
+        });
+    }
+
+    // 특정 스니펫의 태그 로드
+    function loadSnippetTags(snippetId) {
+        const container = $(`#tags-${snippetId}`);
+
+        $.get(`/api/tag/snippet/${snippetId}`)
+            .done(function(tags) {
+                container.empty();
+
+                if (tags.length === 0) {
+                    container.html('<div class="empty-tags">아직 태그가 없습니다</div>');
+                } else {
+                    tags.forEach(tag => {
+                        const badge = $('<span class="tag-badge"></span>')
+                            .text(tag.name)
+                            .append(`<span class="remove-tag" onclick="removeTag(${snippetId}, ${tag.tagId})">×</span>`);
+                        container.append(badge);
+                    });
+                }
+            })
+            .fail(function(xhr) {
+                container.html('<div class="error-message">태그를 불러올 수 없습니다</div>');
+            });
+    }
+
+    // 태그 입력 필드 초기화
+    function initializeTagInputs() {
+        snippetList.forEach(snippet => {
+            const input = $(`#tagInput-${snippet.snippetId}`);
+            const suggestions = $(`#suggestions-${snippet.snippetId}`);
+
+            // 입력 이벤트
+            input.on('input', function() {
+                const value = $(this).val().trim();
+                if (value.length > 0) {
+                    showSuggestions(snippet.snippetId, value);
+                } else {
+                    suggestions.removeClass('show');
+                }
+            });
+
+            // 키보드 이벤트
+            input.on('keydown', function(e) {
+                const suggestions = $(`#suggestions-${snippet.snippetId}`);
+                const items = suggestions.find('.suggestion-item');
+
+                if (e.key === 'ArrowDown') {
+                    e.preventDefault();
+                    selectedSuggestionIndex = Math.min(selectedSuggestionIndex + 1, items.length - 1);
+                    updateSelectedSuggestion(suggestions, selectedSuggestionIndex);
+                } else if (e.key === 'ArrowUp') {
+                    e.preventDefault();
+                    selectedSuggestionIndex = Math.max(selectedSuggestionIndex - 1, -1);
+                    updateSelectedSuggestion(suggestions, selectedSuggestionIndex);
+                } else if (e.key === 'Enter') {
+                    e.preventDefault();
+                    if (selectedSuggestionIndex >= 0) {
+                        items.eq(selectedSuggestionIndex).click();
+                    } else if ($(this).val().trim()) {
+                        addNewTag(snippet.snippetId, $(this).val().trim());
+                    }
+                } else if (e.key === 'Escape') {
+                    suggestions.removeClass('show');
+                    selectedSuggestionIndex = -1;
+                }
+            });
+
+            // 포커스 아웃 이벤트
+            input.on('blur', function() {
+                setTimeout(() => {
+                    suggestions.removeClass('show');
+                    selectedSuggestionIndex = -1;
+                }, 200);
+            });
+        });
+    }
+
+    // 제안 목록 표시
+    function showSuggestions(snippetId, query) {
+        const suggestions = $(`#suggestions-${snippetId}`);
+        suggestions.empty();
+
+        // 기존 태그에서 필터링
+        const filteredTags = allUserTags.filter(tag =>
+            tag.name.toLowerCase().includes(query.toLowerCase())
+        );
+
+        // 정확히 일치하는 태그가 있는지 확인
+        const exactMatch = allUserTags.find(tag =>
+            tag.name.toLowerCase() === query.toLowerCase()
+        );
+
+        // 제안 목록 생성
+        filteredTags.forEach((tag, index) => {
+            const item = $('<div class="suggestion-item"></div>')
+                .text(tag.name)
+                .attr('data-tag-id', tag.tagId)
+                .attr('data-index', index)
+                .on('click', function() {
+                    selectExistingTag(snippetId, tag.tagId, tag.name);
+                });
+            suggestions.append(item);
+        });
+
+        // 새 태그 생성 옵션 추가 (정확히 일치하는 태그가 없을 때만)
+        if (!exactMatch && query.trim()) {
+            const newTagItem = $('<div class="suggestion-item suggestion-new"></div>')
+                .html(`<i class="fas fa-plus-circle me-2"></i>"${query}" 태그 생성`)
+                .attr('data-index', filteredTags.length)
+                .on('click', function() {
+                    addNewTag(snippetId, query);
+                });
+            suggestions.append(newTagItem);
+        }
+
+        suggestions.addClass('show');
+        selectedSuggestionIndex = -1;
+    }
+
+    // 선택된 제안 항목 업데이트
+    function updateSelectedSuggestion(suggestions, index) {
+        suggestions.find('.suggestion-item').removeClass('selected');
+        if (index >= 0) {
+            suggestions.find('.suggestion-item').eq(index).addClass('selected');
+        }
+    }
+
+    // 기존 태그 선택
+    function selectExistingTag(snippetId, tagId, tagName) {
+        showLoading(snippetId, true);
+        showMessage(snippetId, '');
+
+        $.ajax({
+            url: `/api/tag/snippet/${snippetId}/tag/${tagId}`,
+            method: 'POST',
+            contentType: 'application/json',
+            success: function(response) {
+                showMessage(snippetId, `"${tagName}" 태그가 추가되었습니다`, 'success');
+                $(`#tagInput-${snippetId}`).val('');
+                $(`#suggestions-${snippetId}`).removeClass('show');
+                loadSnippetTags(snippetId);
+            },
+            error: function(xhr) {
+                const error = xhr.responseJSON?.error || '태그 추가에 실패했습니다';
+                showMessage(snippetId, error, 'error');
+            },
+            complete: function() {
+                showLoading(snippetId, false);
+            }
+        });
+    }
+
+    // 새 태그 생성 및 추가
+    function addNewTag(snippetId, tagName) {
+        showLoading(snippetId, true);
+        showMessage(snippetId, '');
+
+        // 1. 먼저 태그 생성
+        $.ajax({
+            url: '/api/tag',
+            method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({ name: tagName }),
+            success: function(response) {
+                if (response.success && response.tag) {
+                    // 2. 생성된 태그를 스니펫에 추가
+                    selectExistingTag(snippetId, response.tag.tagId, response.tag.name);
+                    // 전체 태그 목록 갱신
+                    loadAllUserTags();
+                }
+            },
+            error: function(xhr) {
+                const error = xhr.responseJSON?.error || '태그 생성에 실패했습니다';
+                showMessage(snippetId, error, 'error');
+                showLoading(snippetId, false);
+            }
+        });
+    }
+
+    // 태그 제거
+    function removeTag(snippetId, tagId) {
+        if (!confirm('이 태그를 제거하시겠습니까?')) {
+            return;
+        }
+
+        showLoading(snippetId, true);
+
+        $.ajax({
+            url: `/api/tag/snippet/${snippetId}/tag/${tagId}`,
+            method: 'DELETE',
+            success: function() {
+                showMessage(snippetId, '태그가 제거되었습니다', 'success');
+                loadSnippetTags(snippetId);
+            },
+            error: function(xhr) {
+                showMessage(snippetId, '태그 제거에 실패했습니다', 'error');
+            },
+            complete: function() {
+                showLoading(snippetId, false);
+            }
+        });
+    }
+
+    // 로딩 표시
+    function showLoading(snippetId, show) {
+        $(`#loading-${snippetId}`).toggle(show);
+    }
+
+    // 메시지 표시
+    function showMessage(snippetId, message, type = '') {
+        const messageDiv = $(`#message-${snippetId}`);
+        messageDiv.removeClass('error-message success-message');
+
+        if (message) {
+            if (type === 'error') {
+                messageDiv.addClass('error-message');
+            } else if (type === 'success') {
+                messageDiv.addClass('success-message');
+            }
+            messageDiv.text(message);
+
+            // 3초 후 메시지 제거
+            setTimeout(() => {
+                messageDiv.text('');
+            }, 3000);
+        } else {
+            messageDiv.text('');
+        }
+    }
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/tag/tag-manager.html
+++ b/src/main/resources/templates/tag/tag-manager.html
@@ -55,7 +55,7 @@
     <!-- 전체 태그 목록 영역 -->
     <div class="card">
         <div class="card-title">전체 태그 목록</div>
-        <div class="help-message">💡 태그를 클릭하면 해당 태그를 가진 스니펫 목록을 볼 수 있습니다.</div>
+        <div class="help-message">💡 태그를 클릭하면 해당 태그를 가진 스니펫 목록을 볼 수 있습니다. ❌를 클릭하면 태그를 삭제할 수 있습니다.</div>
         <div id="allTags" class="tag-list">
             <div class="loading-text">태그를 불러오는 중...</div>
         </div>
@@ -65,6 +65,24 @@
     <div id="snippetsSection" class="card snippets-section">
         <div class="card-title" id="snippetsTitle">📝 스니펫 목록</div>
         <div id="snippetsGrid" class="snippets-grid"></div>
+    </div>
+</div>
+
+<!-- 태그 삭제 확인 모달 -->
+<div id="deleteModal" class="modal" style="display: none;">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h3>태그 삭제 확인</h3>
+            <span class="modal-close">&times;</span>
+        </div>
+        <div class="modal-body">
+            <p><strong>"<span id="deleteTagName"></span>"</strong> 태그를 삭제하시겠습니까?</p>
+            <p class="warning-text">⚠️ 이 태그와 연결된 모든 스니펫에서도 태그가 제거됩니다.</p>
+        </div>
+        <div class="modal-footer">
+            <button id="confirmDelete" class="btn btn-danger">삭제</button>
+            <button id="cancelDelete" class="btn btn-secondary">취소</button>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
# 태그 관리 기능 개선 및 버그 수정

## 변경 사항

### ✨ 새 기능
- **태그 텍스트 입력 기능**: `snippet-tag.html`에서 직접 태그명을 입력하여 태그 생성 가능

### 🐛 버그 수정
- **MyBatis 자동 생성 키 오류**: `insertTag` 메서드에서 `keyProperty` 매핑 실패 문제 해결
- **변수명 오타**: `snippets` → `snippetList`로 통일
- **사용자 인증 로직**: `null` 체크 강화로 안정성 개선

### 🔧 기술적 변경사항
- **MyBatis 매퍼 수정**
    - 주요 개선점:
      - `@Param` 개별 파라미터에서 `TagItem` 객체로 변경
      - 자동 생성된 `tagId`가 객체에 정상적으로 할당
      - 변수명 일관성 확보
      - 사용자 인증 상태 검증 로직 강화

## 기능 설명

### 태그 추가 플로우
1. 사용자가 텍스트 입력 필드에 태그명 입력
2. 서버에서 `TagItem` 객체 생성 (`userId + name`)
3. DB 삽입 후 자동 생성된 `tagId` 반환
4. 클라이언트에서 새로 생성된 태그 표시

## 🧪 테스트 체크리스트
- 태그 텍스트 입력 기능 동작 확인
- 자동 생성된 `tagId` 정상 반환 확인
- 사용자 인증 상태별 동작 확인
- 변수명 오타 수정 확인
- 기존 태그 기능 정상 동작 확인

## 📋 리뷰 포인트

### 🔍 중점 확인 사항
- MyBatis 매퍼 메서드 파라미터 변경이 적절한지
- 사용자 인증 로직이 모든 케이스를 다루는지
- 프론트엔드 태그 추가 UI/UX가 직관적인지

### 🚨 주의사항
- `TagItem` 객체의 생성자 사용 방식 확인 필요
- 기존 태그 관련 기능에 영향 없는지 검증 필요

## 🔗 관련 이슈
- 태그 생성 시 자동 생성 키 할당 실패 문제
- 사용자별 태그 관리 기능 개선
