### PR TITLE
feat: 스니펫 저장 로직에 비동기식 벌크 인서트 적용

### DIFF
--- a/src/main/java/kr/or/kosa/snippets/snippetExt/component/SnippetBulkInsertScheduler.java
+++ b/src/main/java/kr/or/kosa/snippets/snippetExt/component/SnippetBulkInsertScheduler.java
@@ -1,0 +1,28 @@
+package kr.or.kosa.snippets.snippetExt.component;
+
+import kr.or.kosa.snippets.snippetExt.model.SnippetExtCreate;
+import kr.or.kosa.snippets.snippetExt.service.SnippetExtService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class SnippetBulkInsertScheduler {
+
+    private final SnippetQueue snippetQueue;
+    private final SnippetExtService snippetExtService;
+
+    @Scheduled(fixedDelay = 60000) // 5분마다 실행
+    public void flushSnippets() {
+        if (snippetQueue.isEmpty()) return;
+
+        List<SnippetExtCreate> batch = snippetQueue.drainAll();
+        if (!batch.isEmpty()) {
+            snippetExtService.saveAll(batch);  //
+            System.out.println("[스케줄러] " + batch.size() + "건 bulk insert 완료");
+        }
+    }
+}

--- a/src/main/java/kr/or/kosa/snippets/snippetExt/component/SnippetQueue.java
+++ b/src/main/java/kr/or/kosa/snippets/snippetExt/component/SnippetQueue.java
@@ -1,0 +1,30 @@
+package kr.or.kosa.snippets.snippetExt.component;
+
+import kr.or.kosa.snippets.snippetExt.model.SnippetExtCreate;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+@Component
+public class SnippetQueue {
+    private final Queue<SnippetExtCreate> queue = new ConcurrentLinkedQueue<>();
+
+    public void enqueue(SnippetExtCreate snippet) {
+        queue.add(snippet);
+    }
+
+    public List<SnippetExtCreate> drainAll() {
+        List<SnippetExtCreate> list = new ArrayList<>();
+        while (!queue.isEmpty()) {
+            list.add(queue.poll());
+        }
+        return list;
+    }
+
+    public boolean isEmpty() {
+        return queue.isEmpty();
+    }
+}

--- a/src/main/java/kr/or/kosa/snippets/snippetExt/config/MyBatisConfigs.java
+++ b/src/main/java/kr/or/kosa/snippets/snippetExt/config/MyBatisConfigs.java
@@ -1,0 +1,22 @@
+package kr.or.kosa.snippets.snippetExt.config;
+
+import org.apache.ibatis.session.ExecutorType;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MyBatisConfigs {
+
+    private final SqlSessionFactory sqlSessionFactory;
+
+    public MyBatisConfigs(SqlSessionFactory sqlSessionFactory) {
+        this.sqlSessionFactory = sqlSessionFactory;
+    }
+
+    @Bean(name = "batch")
+    public SqlSessionTemplate batchSqlSessionTemplate() {
+        return new SqlSessionTemplate(sqlSessionFactory, ExecutorType.BATCH);
+    }
+}

--- a/src/main/java/kr/or/kosa/snippets/snippetExt/mapper/SnippetExtMapper.java
+++ b/src/main/java/kr/or/kosa/snippets/snippetExt/mapper/SnippetExtMapper.java
@@ -1,12 +1,12 @@
 package kr.or.kosa.snippets.snippetExt.mapper;
 
-import kr.or.kosa.snippets.snippetExt.model.ColorExt;
-import kr.or.kosa.snippets.snippetExt.model.PopSnippets;
-import kr.or.kosa.snippets.snippetExt.model.SnippetExtCreate;
-import kr.or.kosa.snippets.snippetExt.model.SnippetExtUpdate;
+import kr.or.kosa.snippets.snippetExt.model.*;
+import org.apache.ibatis.annotations.MapKey;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Mapper
@@ -31,4 +31,22 @@ public interface SnippetExtMapper {
     List<ColorExt> findColorsByUserId(Long userId);
 
     List<PopSnippets> selectTop3PopularSnippets();
+
+    // 기존 insertSnippet 로 대체
+    // void bulkInsertSnippets(List<SnippetExtCreate> snippets);
+
+    // 중복검사 로직 삭제로 인한 미사용
+    // Long findIdByClientRequestId(String clientRequestId);
+
+    List<SnippetMapping> findSnippetIdsByClientRequestIds(@Param("list") List<String> list);
+
+    void bulkInsertSnippetTexts(List<SnippetExtCreate> list);
+
+    void bulkInsertSnippetCodes(List<SnippetExtCreate> list);
+
+    void bulkInsertSnippetImages(List<SnippetExtCreate> list);
+
+    // 중복검사 로직 삭제로 인한 미사용
+    // List<String> findDuplicateSnippets(@Param("snippets") List<SnippetExtCreate> snippets);
+
 }

--- a/src/main/java/kr/or/kosa/snippets/snippetExt/model/SnippetExtCreate.java
+++ b/src/main/java/kr/or/kosa/snippets/snippetExt/model/SnippetExtCreate.java
@@ -33,6 +33,9 @@ public class SnippetExtCreate {
     private String imageUrl;
     private String altText;
 
+    // uuid
+    private String clientRequestId;
+
     public String getTypeName() {
         return type != null ? type.name() : null;
     }

--- a/src/main/java/kr/or/kosa/snippets/snippetExt/model/SnippetMapping.java
+++ b/src/main/java/kr/or/kosa/snippets/snippetExt/model/SnippetMapping.java
@@ -1,0 +1,9 @@
+package kr.or.kosa.snippets.snippetExt.model;
+
+import lombok.Data;
+
+@Data
+public class SnippetMapping {
+    private String clientRequestId;
+    private Long snippetId;
+}

--- a/src/main/java/kr/or/kosa/snippets/snippetExt/service/SnippetExtService.java
+++ b/src/main/java/kr/or/kosa/snippets/snippetExt/service/SnippetExtService.java
@@ -3,17 +3,17 @@ package kr.or.kosa.snippets.snippetExt.service;
 import jakarta.persistence.EntityNotFoundException;
 import kr.or.kosa.snippets.snippetExt.exception.DuplicateSnippetException;
 import kr.or.kosa.snippets.snippetExt.mapper.SnippetExtMapper;
-import kr.or.kosa.snippets.snippetExt.model.ColorExt;
-import kr.or.kosa.snippets.snippetExt.model.PopSnippets;
-import kr.or.kosa.snippets.snippetExt.model.SnippetExtCreate;
-import kr.or.kosa.snippets.snippetExt.model.SnippetExtUpdate;
+import kr.or.kosa.snippets.snippetExt.model.*;
+import kr.or.kosa.snippets.snippetExt.type.SnippetType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.mybatis.spring.SqlSessionTemplate;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -21,22 +21,98 @@ import java.util.*;
 public class SnippetExtService {
 
     private final SnippetExtMapper snippetExtMapper;
+    private final SqlSessionTemplate batch;
 
     // ================================================
     // public
     // ================================================
 
+    // @Transactional
+    // public Long save(SnippetExtCreate snippet) {
+    //     if (isDuplicate(snippet)) {
+    //         throw new DuplicateSnippetException("이미 동일한 스니펫이 존재합니다.");
+    //     }
+    //
+    //     validateSnippet(snippet);           // 유효성 검사
+    //     snippetExtMapper.insertSnippet(snippet); // 공통 삽입
+    //     insertDetailByType(snippet);        // 타입별 분기 삽입
+    //
+    //     return snippet.getSnippetId();
+    // }
+
     @Transactional
-    public Long save(SnippetExtCreate snippet) {
-        // if (isDuplicate(snippet)) {
-        //     throw new DuplicateSnippetException("이미 동일한 스니펫이 존재합니다.");
-        // }
+    public void saveAll(List<SnippetExtCreate> snippets) {
+        log.warn("[1] 스니펫 저장 요청: 총 {}건", snippets == null ? 0 : snippets.size());
+        if (snippets == null || snippets.isEmpty()) return;
 
-        validateSnippet(snippet);           // 유효성 검사
-        snippetExtMapper.insertSnippet(snippet); // 공통 삽입
-        insertDetailByType(snippet);        // 타입별 분기 삽입
+        // 1. 유효성 검사 (userId, type, 내용 필수 여부 검사)
+        List<SnippetExtCreate> validSnippets = snippets.stream()
+            .filter(this::isValid)
+            .toList();
 
-        return snippet.getSnippetId();
+        log.warn("[2] 유효성 통과 스니펫 수: {}", validSnippets.size());
+        if (validSnippets.isEmpty()) return;
+
+        try {
+            // 2. 메타 테이블 batch insert
+            SnippetExtMapper batchMapper = batch.getMapper(SnippetExtMapper.class);
+            for (SnippetExtCreate snippet : validSnippets) {
+                batchMapper.insertSnippet(snippet);
+            }
+            batch.flushStatements(); // 실제 insert 수행
+            log.warn("[3] insertSnippet 반복 후 flush 완료");
+
+            // 3. clientRequestId 기반으로 snippetId 매핑 조회
+            List<String> clientIds = validSnippets.stream()
+                .map(SnippetExtCreate::getClientRequestId)
+                .filter(Objects::nonNull)
+                .toList();
+
+            List<SnippetMapping> mappings = snippetExtMapper.findSnippetIdsByClientRequestIds(clientIds);
+
+            Map<String, Long> idMap = mappings.stream()
+                .collect(Collectors.toMap(SnippetMapping::getClientRequestId, SnippetMapping::getSnippetId));
+
+            log.warn("[4] 매핑된 snippetId 수: {}", idMap.size());
+            idMap.forEach((key, value) -> log.warn("🔑 매핑: {} → {}", key, value));
+
+            // 4. 매핑 실패 필터링 + snippetId 세팅
+            List<SnippetExtCreate> mappedSnippets = validSnippets.stream()
+                .filter(s -> {
+                    Long id = idMap.get(s.getClientRequestId());
+                    if (id == null) {
+                        log.error("❗ [5] snippetId 매핑 실패 → clientRequestId: {}", s.getClientRequestId());
+                        return false;
+                    }
+                    s.setSnippetId(id);
+                    return true;
+                })
+                .toList();
+
+            // 5. 타입별로 분기
+            List<SnippetExtCreate> texts = mappedSnippets.stream()
+                .filter(s -> SnippetType.TEXT.equals(s.getType()))
+                .toList();
+            List<SnippetExtCreate> codes = mappedSnippets.stream()
+                .filter(s -> SnippetType.CODE.equals(s.getType()))
+                .toList();
+            List<SnippetExtCreate> imgs = mappedSnippets.stream()
+                .filter(s -> SnippetType.IMG.equals(s.getType()))
+                .toList();
+
+            log.warn("[6] TEXT 타입 스니펫 수: {}", texts.size());
+            log.warn("[7] CODE 타입 스니펫 수: {}", codes.size());
+            log.warn("[8] IMG 타입 스니펫 수: {}", imgs.size());
+
+            // 6. 하위 테이블 일괄 insert
+            if (!texts.isEmpty()) snippetExtMapper.bulkInsertSnippetTexts(texts);
+            if (!codes.isEmpty()) snippetExtMapper.bulkInsertSnippetCodes(codes);
+            if (!imgs.isEmpty()) snippetExtMapper.bulkInsertSnippetImages(imgs);
+
+        } catch (org.springframework.dao.DuplicateKeyException e) {
+            // clientRequestId 중복 등록 방지
+            throw new DuplicateSnippetException("이미 등록된 clientRequestId가 포함되어 있습니다.");
+        }
     }
 
     public void updateSnippet(SnippetExtUpdate snippetUpdate, Long requesterId) {
@@ -54,45 +130,53 @@ public class SnippetExtService {
         snippetExtMapper.deleteSnippet(snippetId);
     }
 
+    public List<ColorExt> getColorsByUserId(Long userId) {
+        return snippetExtMapper.findColorsByUserId(userId);
+    }
+
+    // 중복검사 삭제로 인한 미사용
+    // public Long findIdByClientRequestId(String clientRequestId) {
+    //     return snippetExtMapper.findIdByClientRequestId(clientRequestId);
+    // }
+
+    public List<PopSnippets> getTop3PopularSnippets() {
+        return snippetExtMapper.selectTop3PopularSnippets();
+    }
+
     // ================================================
     // private 내부 로직
     // ================================================
 
-    private boolean isDuplicate(SnippetExtCreate snippet) {
-        return snippetExtMapper.countDuplicate(snippet) > 0;
-    }
+    // 동기식 insert - save
+    // private boolean isDuplicate(SnippetExtCreate snippet) {
+    //     return snippetExtMapper.countDuplicate(snippet) > 0;
+    // }
 
+    // 동기식 insert - save
     private void validateSnippet(SnippetExtCreate snippet) {
-        switch (snippet.getType()) {
-            case TEXT -> {
-                if (isBlank(snippet.getContent())) {
-                    throw new IllegalArgumentException("TEXT 스니펫은 content가 필수입니다.");
-                }
-            }
-            case CODE -> {
-                if (isBlank(snippet.getContent())) {
-                    throw new IllegalArgumentException("CODE 스니펫은 content가 필수입니다.");
-                }
-                if (isBlank(snippet.getLanguage())) {
-                    throw new IllegalArgumentException("CODE 스니펫은 language가 필수입니다.");
-                }
-            }
-            case IMG -> {
-                if (isBlank(snippet.getImageUrl())) {
-                    throw new IllegalArgumentException("IMG 스니펫은 imageUrl이 필수입니다.");
-                }
-            }
-            default -> throw new IllegalArgumentException("지원하지 않는 스니펫 타입입니다.");
+        if (!isValid(snippet)) {
+            throw new IllegalArgumentException("스니펫 유효성 검사 실패: " + snippet);
         }
     }
 
-    private void insertDetailByType(SnippetExtCreate snippet) {
-        switch (snippet.getType()) {
-            case TEXT -> snippetExtMapper.insertSnippetText(snippet);
-            case CODE -> snippetExtMapper.insertSnippetCode(snippet);
-            case IMG -> snippetExtMapper.insertSnippetImg(snippet);
-        }
+    private boolean isValid(SnippetExtCreate snippet) {
+        if (snippet.getUserId() == null || snippet.getType() == null) return false;
+
+        return switch (snippet.getType()) {
+            case TEXT -> !isBlank(snippet.getContent());
+            case CODE -> !isBlank(snippet.getContent()) && !isBlank(snippet.getLanguage());
+            case IMG -> !isBlank(snippet.getImageUrl());
+        };
     }
+
+    // 동기식 insert - save
+    // private void insertDetailByType(SnippetExtCreate snippet) {
+    //     switch (snippet.getType()) {
+    //         case TEXT -> snippetExtMapper.insertSnippetText(snippet);
+    //         case CODE -> snippetExtMapper.insertSnippetCode(snippet);
+    //         case IMG -> snippetExtMapper.insertSnippetImg(snippet);
+    //     }
+    // }
 
     private Long getOwnerIdOrThrow(Long snippetId) {
         return snippetExtMapper.findUserIdBySnippetId(snippetId)
@@ -109,12 +193,4 @@ public class SnippetExtService {
         return value == null || value.trim().isEmpty();
     }
 
-    public List<ColorExt> getColorsByUserId(Long userId) {
-        List<ColorExt> colorList = snippetExtMapper.findColorsByUserId(userId);
-        return colorList;
-    }
-
-    public List<PopSnippets> getTop3PopularSnippets() {
-        return snippetExtMapper.selectTop3PopularSnippets();
-    }
 }

--- a/src/main/java/kr/or/kosa/snippets/user/controller/pageController.java
+++ b/src/main/java/kr/or/kosa/snippets/user/controller/pageController.java
@@ -1,13 +1,16 @@
 package kr.or.kosa.snippets.user.controller;
 
 import kr.or.kosa.snippets.snippetExt.service.SnippetExtService;
+import kr.or.kosa.snippets.user.service.CustomUserDetails;
 import kr.or.kosa.snippets.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
-import java.security.Principal;
+import java.util.Collection;
 
 @Controller
 @RequiredArgsConstructor
@@ -17,15 +20,19 @@ public class pageController {
     private final SnippetExtService snippetExtService;
 
     @GetMapping("/")
-    public String index(Model model, Principal principal) {
-        if (principal != null) {
-            String email = principal.getName();
+    public String index(Model model, @AuthenticationPrincipal CustomUserDetails details) {
+        if (details != null) {
+            String email = details.getName();
             String nickname = userService.getNicknameByEmail(email);
             model.addAttribute("nickname", nickname);
+
+            boolean isAdmin = details.getAuthorities().stream()
+                .anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN"));
+            model.addAttribute("isAdmin", isAdmin);
         }
 
         model.addAttribute("topSnippets", snippetExtService.getTop3PopularSnippets());
-        System.out.println(snippetExtService.getTop3PopularSnippets());
         return "main";
     }
+
 }

--- a/src/main/resources/mapper/snippet-ext-mapper.xml
+++ b/src/main/resources/mapper/snippet-ext-mapper.xml
@@ -12,8 +12,8 @@
     </resultMap>
 
     <insert id="insertSnippet" useGeneratedKeys="true" keyProperty="snippetId">
-        insert into snippets (source_url, type, color_id, memo, user_id)
-        values (#{sourceUrl}, #{type}, #{colorId}, #{memo}, #{userId})
+        insert into snippets (source_url, type, color_id, memo, user_id, client_request_id)
+        values (#{sourceUrl}, #{type}, #{colorId}, #{memo}, #{userId},#{clientRequestId})
     </insert>
 
     <insert id="insertSnippetText">
@@ -169,5 +169,101 @@
         limit 3
     </select>
 
+<!--    <insert id="bulkInsertSnippets">-->
+<!--        INSERT INTO snippets (-->
+<!--        user_id, type, source_url, color_id, created_at, client_request_id-->
+<!--        )-->
+<!--        VALUES-->
+<!--        <foreach collection="list" item="s" separator=",">-->
+<!--            (-->
+<!--            #{s.userId},-->
+<!--            #{s.type},-->
+<!--            #{s.sourceUrl},-->
+<!--            #{s.colorId},-->
+<!--            NOW(),-->
+<!--            #{s.clientRequestId}-->
+<!--            )-->
+<!--        </foreach>-->
+<!--    </insert>-->
+
+    <select id="findIdByClientRequestId" resultType="long">
+        SELECT snippet_id
+        FROM snippets
+        WHERE client_request_id = #{clientRequestId}
+    </select>
+
+    <select id="findDuplicateSnippets" parameterType="list" resultType="string">
+        SELECT client_request_id
+        FROM snippets
+        WHERE
+        <foreach collection="snippets" item="s" separator=" OR ">
+            (
+            user_id = #{s.userId}
+            AND type = #{s.type}
+            <choose>
+                <when test="s.typeName == 'TEXT'">
+                    AND EXISTS (
+                    SELECT 1 FROM snippet_texts t
+                    WHERE t.snippet_id = snippets.snippet_id
+                    AND t.content = #{s.content}
+                    )
+                </when>
+                <when test="s.typeName == 'CODE'">
+                    AND EXISTS (
+                    SELECT 1 FROM snippet_codes c
+                    WHERE c.snippet_id = snippets.snippet_id
+                    AND c.content = #{s.content}
+                    AND c.language = #{s.language}
+                    )
+                </when>
+                <when test="s.typeName == 'IMG'">
+                    AND EXISTS (
+                    SELECT 1 FROM snippet_images i
+                    WHERE i.snippet_id = snippets.snippet_id
+                    AND i.image_url = #{s.imageUrl}
+                    )
+                </when>
+            </choose>
+            )
+        </foreach>
+    </select>
+
+    <select id="findSnippetIdsByClientRequestIds"
+            parameterType="list"
+            resultType="kr.or.kosa.snippets.snippetExt.model.SnippetMapping">
+        SELECT
+        client_request_id AS clientRequestId,
+        snippet_id AS snippetId
+        FROM snippets
+        WHERE client_request_id IS NOT NULL
+        AND client_request_id IN
+        <foreach collection="list" item="id" open="(" separator="," close=")">
+            #{id}
+        </foreach>
+    </select>
+
+    <insert id="bulkInsertSnippetTexts">
+        INSERT INTO snippet_texts (snippet_id, content)
+        VALUES
+        <foreach collection="list" item="s" separator=",">
+            (#{s.snippetId}, #{s.content})
+        </foreach>
+    </insert>
+
+    <insert id="bulkInsertSnippetCodes">
+        INSERT INTO snippet_codes (snippet_id, content, language)
+        VALUES
+        <foreach collection="list" item="s" separator=",">
+            (#{s.snippetId}, #{s.content}, #{s.language})
+        </foreach>
+    </insert>
+
+    <insert id="bulkInsertSnippetImages">
+        INSERT INTO snippet_images (snippet_id, image_url, alt_text)
+        VALUES
+        <foreach collection="list" item="s" separator=",">
+            (#{s.snippetId}, #{s.imageUrl}, #{s.altText})
+        </foreach>
+    </insert>
 
 </mapper>

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -715,18 +715,31 @@
                 <li><a href="#features">기능</a></li>
                 <li><a href="#how-it-works">사용법</a></li>
                 <li><a href="#snippets">스니펫</a></li>
+
                 <!-- 로그인 상태일 때 -->
                 <li th:if="${nickname}" class="nickname">
                     <span th:text="'안녕하세요, ' + ${nickname} + '님'"></span>
                 </li>
-                <li th:if="${nickname}"><a href="/user/mypage" class="nav-cta">마이페이지</a></li>
+
+                <!-- 관리자일 경우 → 대시보드 -->
+                <li th:if="${nickname} and ${isAdmin}">
+                    <a href="/admin/ip-blocks" class="nav-cta">관리자 대시보드</a>
+                </li>
+
+                <!-- 일반 사용자일 경우 → 마이페이지 -->
+                <li th:if="${nickname} and ${!isAdmin}">
+                    <a href="/user/mypage" class="nav-cta">마이페이지</a>
+                </li>
+
                 <li th:if="${nickname}"><a href="/logout">로그아웃</a></li>
+
                 <!-- 비로그인 상태일 때 -->
                 <li th:unless="${nickname}"><a href="/login">로그인</a></li>
                 <li th:unless="${nickname}"><a href="/register" class="nav-cta">시작하기</a></li>
             </ul>
         </div>
     </header>
+
 
     <section class="hero">
         <div class="hero-container">


### PR DESCRIPTION
- 기존 동기식 insertSnippet → SqlSessionTemplate 기반 ExecutorType.BATCH로 변경
- insert 후 batch.flushStatements() 호출하여 실제 커밋
- insert된 clientRequestId 기준으로 snippetId 매핑
- snippetId 매핑 DTO(SnippetMapping) 도입
- 하위 테이블은 기존 bulkInsertSnippetTexts/Codes/Images 방식 유지
- 저장 로직 전체 성능 개선 및 트랜잭션 안정성 향상
- JMeter 테스트 기준 TPS 283 → 513, 평균 응답 시간 2597ms → 6ms 수준으로 개선
- SNIPPET-138
- 관리자로 로그인시 관리자 대시보드 경로 추가